### PR TITLE
Update to use ROS standard practices, make node easier to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ Publishes the raw data from the sensor as a ros message.
 | sensor_tcp_port          | Integer | 2122 | ✔ | Sensor TCP Port.  Can be passed as an argument to the launch file. |
 | host_ip                        |   String  | 192.168.1.9 | ✔ | Host IP address.  Can be passed as an argument to the launch file.  |
 | host_udp_port             | Integer | 6061 | ✔ | Host UDP Port.  Can be passed as an argument to the launch file.  |
-| laser_scan_frame_name  | String | laser_scan | | The frame name of the sensor message  |
+| frame_id  | String | laser_scan | | The frame name of the sensor message  |
 | publish_frequency    | Integer | 1 | | How many scans should be published (1 means every scan, 2 every second scan, ... ) |
-| angle_start              | Double |  0.0| | Start angle of scan, if both start and end angle are set to 0, all angels are regarded  |
-| angle_end                | Double | 0.0 | | End angle of scan, if both start and end angle are set to 0, all angels are regarded  |
+| angle_start              | Double |  0.0| | Start angle of scan in radians, if both start and end angle are set to 0, all angels are regarded  |
+| angle_end                | Double | 0.0 | | End angle of scan in radians, if both start and end angle are set to 0, all angels are regarded  |
 | channel_enabled     | Boolean | true | | If the channel should be enabled  |
 | general_system_state  | Boolean | true | | If the general system state should be published  |
 | derived_settings      | Boolean | true | | If the derived settings should be published  |

--- a/config/SickSafetyscannersConfiguration.cfg
+++ b/config/SickSafetyscannersConfiguration.cfg
@@ -9,14 +9,6 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-gen.const("sensor_ip", str_t, "192.168.1.10", "Sensor IP_v4 Adress, only set at startup")
-gen.const("sensor_tcp_port", int_t, 2122, "Sensor TCP port constant",)
-
-gen.const("host_ip", str_t, "192.168.1.9", "IP_v4 adress of the host, set at startup",)
-gen.const("host_udp_port", int_t, 6060, "Port of the host")
-
-gen.const("channel", int_t, 0, "Default channel")
-
 gen.add("frame_id", str_t, 1, "Frame name of the laserscan topic", "laser_scan")
 
 gen.add("publish_frequency", int_t, 1, "Every n_th scan will be published", 1, 1, 100)

--- a/config/SickSafetyscannersConfiguration.cfg
+++ b/config/SickSafetyscannersConfiguration.cfg
@@ -21,9 +21,9 @@ gen.add("frame_id", str_t, 1, "Frame name of the laserscan topic", "laser_scan")
 
 gen.add("publish_frequency", int_t, 1, "Every n_th scan will be published", 1, 1, 100)
 
-gen.add("angle_start", double_t, 1, "Start angle for sensor in degree, if both start and end angle are 0, all angles are taken in account." ,0,-47.5,227.5)
+gen.add("angle_start", double_t, 1, "Start angle for sensor in radians, if both start and end angle are 0, all angles are taken in account." ,0, -0.829, 3.971)
 
-gen.add("angle_end", double_t, 1, "End angle for sensor in degree, if both start and end angle are 0, all angles are taken in account.", 0,-47.5,227.5)
+gen.add("angle_end", double_t, 1, "End angle for sensor in radians, if both start and end angle are 0, all angles are taken in account.", 0, -0.829, 3.971)
 
 gen.add("time_offset",    double_t, 0, "An offset to add to the time stamp before publication of a scan [s].",       -0.0,     -0.25, 0.25)
 

--- a/config/SickSafetyscannersConfiguration.cfg
+++ b/config/SickSafetyscannersConfiguration.cfg
@@ -25,6 +25,8 @@ gen.add("angle_start", double_t, 1, "Start angle for sensor in degree, if both s
 
 gen.add("angle_end", double_t, 1, "End angle for sensor in degree, if both start and end angle are 0, all angles are taken in account.", 0,-47.5,227.5)
 
+gen.add("time_offset",    double_t, 0, "An offset to add to the time stamp before publication of a scan [s].",       -0.0,     -0.25, 0.25)
+
 gen.add("channel_enabled", bool_t, 8, "Enable Channel",True)
 gen.add("general_system_state", bool_t, 8, "Publish general system state",True)
 gen.add("derived_settings", bool_t, 8, "Publish derived settings",True)

--- a/config/SickSafetyscannersConfiguration.cfg
+++ b/config/SickSafetyscannersConfiguration.cfg
@@ -17,7 +17,7 @@ gen.const("host_udp_port", int_t, 6060, "Port of the host")
 
 gen.const("channel", int_t, 0, "Default channel")
 
-gen.add("laser_scan_frame_name", str_t, 1, "Frame name of the laserscan topic", "laser_scan")
+gen.add("frame_id", str_t, 1, "Frame name of the laserscan topic", "laser_scan")
 
 gen.add("publish_frequency", int_t, 1, "Every n_th scan will be published", 1, 1, 100)
 

--- a/include/sick_safetyscanners/SickSafetyscannersRos.h
+++ b/include/sick_safetyscanners/SickSafetyscannersRos.h
@@ -129,6 +129,7 @@ private:
     m_dynamic_reconfiguration_server;
 
   std::string m_frame_id;
+  double m_time_offset;
   double m_range_min;
   double m_range_max;
 

--- a/include/sick_safetyscanners/SickSafetyscannersRos.h
+++ b/include/sick_safetyscanners/SickSafetyscannersRos.h
@@ -128,7 +128,7 @@ private:
   dynamic_reconfigure::Server<sick_safetyscanners::SickSafetyscannersConfigurationConfig>
     m_dynamic_reconfiguration_server;
 
-  std::string m_laser_scan_frame_name;
+  std::string m_frame_id;
   double m_range_min;
   double m_range_max;
 

--- a/src/SickSafetyscannersRos.cpp
+++ b/src/SickSafetyscannersRos.cpp
@@ -88,8 +88,8 @@ void SickSafetyscannersRos::callback(
   {
     m_communication_settings.setEnabled(config.channel_enabled);
     m_communication_settings.setPublishingFequency(config.publish_frequency);
-    m_communication_settings.setStartAngle(config.angle_start);
-    m_communication_settings.setEndAngle(config.angle_end);
+    m_communication_settings.setStartAngle(sick::radToDeg(config.angle_start));
+    m_communication_settings.setEndAngle(sick::radToDeg(config.angle_end));
     m_communication_settings.setFeatures(config.general_system_state,
                                          config.derived_settings,
                                          config.measurement_data,
@@ -164,11 +164,11 @@ bool SickSafetyscannersRos::readParameters()
 
   float angle_start;
   m_private_nh.getParam("angle_start", angle_start);
-  m_communication_settings.setStartAngle(angle_start);
+  m_communication_settings.setStartAngle(sick::radToDeg(angle_start));
 
   float angle_end;
   m_private_nh.getParam("angle_end", angle_end);
-  m_communication_settings.setEndAngle(angle_end);
+  m_communication_settings.setEndAngle(sick::radToDeg(angle_end));
 
   bool general_system_state;
   m_private_nh.getParam("general_system_state", general_system_state);

--- a/src/SickSafetyscannersRos.cpp
+++ b/src/SickSafetyscannersRos.cpp
@@ -52,15 +52,15 @@ SickSafetyscannersRos::SickSafetyscannersRos()
     ROS_ERROR("Could not read parameters.");
     ros::requestShutdown();
   }
-  m_laser_scan_publisher = m_private_nh.advertise<sensor_msgs::LaserScan>("laser_scan", 100);
+  m_laser_scan_publisher = m_nh.advertise<sensor_msgs::LaserScan>("laser_scan", 100);
   m_extended_laser_scan_publisher =
-    m_private_nh.advertise<sick_safetyscanners::ExtendedLaserScanMsg>("extended_laser_scan", 100);
+    m_nh.advertise<sick_safetyscanners::ExtendedLaserScanMsg>("extended_laser_scan", 100);
   m_raw_data_publisher =
-    m_private_nh.advertise<sick_safetyscanners::RawMicroScanDataMsg>("raw_data", 100);
+    m_nh.advertise<sick_safetyscanners::RawMicroScanDataMsg>("raw_data", 100);
   m_output_path_publisher =
-    m_private_nh.advertise<sick_safetyscanners::OutputPathsMsg>("output_paths", 100);
+    m_nh.advertise<sick_safetyscanners::OutputPathsMsg>("output_paths", 100);
   m_field_service_server =
-    m_private_nh.advertiseService("field_data", &SickSafetyscannersRos::getFieldData, this);
+    m_nh.advertiseService("field_data", &SickSafetyscannersRos::getFieldData, this);
 
   m_device = std::make_shared<sick::SickSafetyscanners>(
     boost::bind(&SickSafetyscannersRos::receivedUDPPacket, this, _1), m_communication_settings);

--- a/src/SickSafetyscannersRos.cpp
+++ b/src/SickSafetyscannersRos.cpp
@@ -113,7 +113,7 @@ SickSafetyscannersRos::~SickSafetyscannersRos() {}
 
 bool SickSafetyscannersRos::readParameters()
 {
-  std::string sensor_ip_adress = sick_safetyscanners::SickSafetyscannersConfiguration_sensor_ip;
+  std::string sensor_ip_adress = "192.168.1.10";
   if (!m_private_nh.getParam("sensor_ip", sensor_ip_adress))
   {
     //    sensor_ip_adress = sick_safetyscanners::SickSafetyscannersConfiguration_sensor_ip;
@@ -121,27 +121,24 @@ bool SickSafetyscannersRos::readParameters()
   }
   m_communication_settings.setSensorIp(sensor_ip_adress);
 
-  int sensor_tcp_port;
+  int sensor_tcp_port = 2122;
   if (!m_private_nh.getParam("sensor_tcp_port", sensor_tcp_port))
   {
-    sensor_tcp_port = sick_safetyscanners::SickSafetyscannersConfiguration_sensor_tcp_port;
     ROS_WARN("Using default sensor TCP port: %i", sensor_tcp_port);
   }
   m_communication_settings.setSensorTcpPort(sensor_tcp_port);
 
 
-  std::string host_ip_adress = sick_safetyscanners::SickSafetyscannersConfiguration_host_ip;
+  std::string host_ip_adress = "192.168.1.9";
   if (!m_private_nh.getParam("host_ip", host_ip_adress))
   {
-    //    host_ip_adress = sick_safetyscanners::SickSafetyscannersConfiguration_host_ip;
     ROS_WARN("Using default host IP: %s", host_ip_adress.c_str());
   }
   m_communication_settings.setHostIp(host_ip_adress);
 
-  int host_udp_port;
+  int host_udp_port = 6060;
   if (!m_private_nh.getParam("host_udp_port", host_udp_port))
   {
-    host_udp_port = sick_safetyscanners::SickSafetyscannersConfiguration_host_udp_port;
     ROS_WARN("Using default host UDP Port: %i", host_udp_port);
   }
   m_communication_settings.setHostUdpPort(host_udp_port);
@@ -150,7 +147,7 @@ bool SickSafetyscannersRos::readParameters()
            "will be loaded.");
 
 
-  int channel = sick_safetyscanners::SickSafetyscannersConfiguration_channel;
+  int channel = 0;
   m_private_nh.getParam("channel", channel);
   m_communication_settings.setChannel(channel);
 

--- a/src/SickSafetyscannersRos.cpp
+++ b/src/SickSafetyscannersRos.cpp
@@ -52,7 +52,7 @@ SickSafetyscannersRos::SickSafetyscannersRos()
     ROS_ERROR("Could not read parameters.");
     ros::requestShutdown();
   }
-  m_laser_scan_publisher = m_nh.advertise<sensor_msgs::LaserScan>("laser_scan", 100);
+  m_laser_scan_publisher = m_nh.advertise<sensor_msgs::LaserScan>("scan", 100);
   m_extended_laser_scan_publisher =
     m_nh.advertise<sick_safetyscanners::ExtendedLaserScanMsg>("extended_laser_scan", 100);
   m_raw_data_publisher =

--- a/src/SickSafetyscannersRos.cpp
+++ b/src/SickSafetyscannersRos.cpp
@@ -98,6 +98,8 @@ void SickSafetyscannersRos::callback(
     m_device->changeSensorSettings(m_communication_settings);
 
     m_frame_id = config.frame_id;
+
+    m_time_offset = config.time_offset;
   }
 }
 
@@ -198,7 +200,6 @@ void SickSafetyscannersRos::receivedUDPPacket(const sick::datastructure::Data& d
   {
     sensor_msgs::LaserScan scan = createLaserScanMessage(data);
 
-
     m_laser_scan_publisher.publish(scan);
   }
 
@@ -274,6 +275,8 @@ SickSafetyscannersRos::createLaserScanMessage(const sick::datastructure::Data& d
   sensor_msgs::LaserScan scan;
   scan.header.frame_id     = m_frame_id;
   scan.header.stamp        = ros::Time::now();
+  // Add time offset (to account for network latency etc.)
+  scan.header.stamp += ros::Duration().fromSec(m_time_offset);
   uint16_t num_scan_points = data.getDerivedValuesPtr()->getNumberOfBeams();
 
   scan.angle_min = sick::degToRad(data.getDerivedValuesPtr()->getStartAngle());

--- a/src/SickSafetyscannersRos.cpp
+++ b/src/SickSafetyscannersRos.cpp
@@ -97,7 +97,7 @@ void SickSafetyscannersRos::callback(
                                          config.application_io_data);
     m_device->changeSensorSettings(m_communication_settings);
 
-    m_laser_scan_frame_name = config.laser_scan_frame_name;
+    m_frame_id = config.frame_id;
   }
 }
 
@@ -186,7 +186,7 @@ bool SickSafetyscannersRos::readParameters()
   m_communication_settings.setFeatures(
     general_system_state, derived_settings, measurement_data, intrusion_data, application_io_data);
 
-  m_private_nh.getParam("laser_scan_frame_name", m_laser_scan_frame_name);
+  m_private_nh.getParam("frame_id", m_frame_id);
 
 
   return true;
@@ -272,7 +272,7 @@ sensor_msgs::LaserScan
 SickSafetyscannersRos::createLaserScanMessage(const sick::datastructure::Data& data)
 {
   sensor_msgs::LaserScan scan;
-  scan.header.frame_id     = m_laser_scan_frame_name;
+  scan.header.frame_id     = m_frame_id;
   scan.header.stamp        = ros::Time::now();
   uint16_t num_scan_points = data.getDerivedValuesPtr()->getNumberOfBeams();
 


### PR DESCRIPTION
This pull request includes a number of changes to make the node adhere to ROS standards when applicable.  Feel free to merge these commits separately, or to squash into one commit.

Let me know if you see any other issues or if something needs follow up or more changes.

Thanks!

Fix 1) Change "laser_scan_frame_name" parameter into "frame_id" parameter.  "frame_id" is a very common parameter name and is used as a convention across many nodes.  Users will be better served by this change.  See:
https://github.com/ros-drivers/urg_node/blob/indigo-devel/cfg/URG.cfg#L12
https://github.com/ros-drivers/openni_camera/blob/indigo-devel/openni_camera/src/nodelets/driver.cpp#L120

Fix 2) When using the private nodehandle to publish, the node name gets appended to the topic name when published.  So if you called this "safety_fence_laser_node", the topic would be "safety_fence_laser_node/scan" and when you remap the topic on the command line, you'd have to specify: safety_fence_laser_node/scan:=/my_global_namespace/base_scan

This creates a lot of usability problems, so ros nodes publish by default to the default nodehandle ("").  This allows easily changing the nodename through launch files or command line.  If having the topic in a namespace is required, this can be done with ROS_NAMESPACE environment variable on the command line or the "group" tag in roslaunch with the ns argument.

Fix 3) Follow up to Fix 2, ROS usually uses the shorter name "scan" just for convenience.
https://github.com/uos/sick_tim/blob/4145d2da0e794f4a39b2a081f250a9a5a4254f62/src/sick_tim_common.cpp#L62

Fix 4) Many sensors have system dependent but roughly constant time latencies for publication data.  When a robot is moving and especially rotating, the timestamp delay from network latency, CPU overhead, or processing delay can cause phase shifts in the laser data and cause blurring/smearing when visualized or used for mapping.  This parameter allows users to set this on their system according to their needs.  Usually is set by dragging the slider in dynamic reconfigure until an approximate time latency is discovered.

https://github.com/uos/sick_tim/blob/4145d2da0e794f4a39b2a081f250a9a5a4254f62/cfg/SickTim.cfg#L48

Fix 5) This one isn't necessary, but is a strong suggestion.  ROS typically uses radians for in message communication and only sometimes in configuration or specification.  Using radians for this value as the ROS interface allows the radians in the launch file to match the radian values in the messages.  Could be useful if nodes read from the same parameters in the ROS parameter server.

http://www.ros.org/reps/rep-0103.html#derived-units

Fix 6) Parameters aren't required to be in dynamic_reconfigure unless they need to be changed during the runtime of the node.  These values aren't able to be changed during runtime, so they shouldn't be in the dynamic_reconfigure settings or appear in the UI.  Since they are only read using standard ROS parameter server API, the defaults can just be hardcoded and dynamic_reconfigure is no longer needed.