### PR TITLE
Allow system to choose the host udp port from the ephemeral range

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Returns all configured protective and warning fields for the sensor
 | sensor_ip                    | String | 192.168.1.11 | ✔ |Sensor IP address. Can be passed as an argument to the launch file. |
 | sensor_tcp_port          | Integer | 2122 | ✔ | Sensor TCP Port.  Can be passed as an argument to the launch file. |
 | host_ip                        |   String  | 192.168.1.9 | ✔ | Host IP address.  Can be passed as an argument to the launch file.  |
-| host_udp_port             | Integer | 6061 | ✔ | Host UDP Port.  Can be passed as an argument to the launch file.  |
+| host_udp_port             | Integer | 0 | | Host UDP Port.  Can be passed as an argument to the launch file.  Zero allows system chosen port. |
 | frame_id  | String | scan | | The frame name of the sensor message  |
 | skip    | Integer | 0 | | The number of scans to skip between each measured scan.  For a 25Hz laser, setting 'skip' to 0 makes it publish at 25Hz, 'skip' to 1 makes it publish at 12.5Hz. |
 | angle_start              | Double |  0.0| | Start angle of scan in radians, if both start and end angle are set to 0, all angels are regarded  |

--- a/include/sick_safetyscanners/SickSafetyscanners.h
+++ b/include/sick_safetyscanners/SickSafetyscanners.h
@@ -83,7 +83,7 @@ public:
    * \param settings Current settings for the sensor.
    */
   SickSafetyscanners(packetReceivedCallbackFunction newPacketReceivedCallbackFunction,
-                     sick::datastructure::CommSettings settings);
+                     sick::datastructure::CommSettings* settings);
 
   /*!
    * \brief Destructor

--- a/include/sick_safetyscanners/cola2/ChangeCommSettingsCommand.h
+++ b/include/sick_safetyscanners/cola2/ChangeCommSettingsCommand.h
@@ -103,7 +103,7 @@ private:
   void writeChannelToDataPtr(uint8_t*& data_ptr) const;
   void writeEnabledToDataPtr(uint8_t*& data_ptr) const;
   void writeEInterfaceTypeToDataPtr(uint8_t*& data_ptr) const;
-  void writeIPAdresstoDataPtr(uint8_t*& data_ptr) const;
+  void writeIPAddresstoDataPtr(uint8_t*& data_ptr) const;
   void writePortToDataPtr(uint8_t*& data_ptr) const;
   void writeFrequencyToDataPtr(uint8_t*& data_ptr) const;
   void writeStartAngleToDataPtr(uint8_t*& data_ptr) const;

--- a/include/sick_safetyscanners/communication/AsyncUDPClient.h
+++ b/include/sick_safetyscanners/communication/AsyncUDPClient.h
@@ -83,6 +83,12 @@ public:
    */
   void runService();
 
+  /*!
+   * \brief Returns the actual port assigned to the local machine
+   * \return Local port number
+   */
+  unsigned short get_local_port();
+
 private:
   datastructure::PacketBuffer::ArrayBuffer m_recv_buffer;
 

--- a/launch/sick_safetyscanners.launch
+++ b/launch/sick_safetyscanners.launch
@@ -2,7 +2,7 @@
   <arg name="sensor_ip" default="192.168.1.11" />
   <arg name="sensor_tcp_port" default="2122" />
   <arg name="host_ip" default="192.168.1.9" />
-  <arg name="host_udp_port" default="6061" />
+  <arg name="host_udp_port" default="0" />
 
   <!-- Launch Sick SickSafetyscanners Ros Driver Node -->
   <node pkg="sick_safetyscanners" type="sick_safetyscanners_node" name="sick_safetyscanners" output="screen" ns="sick_safetyscanners">

--- a/src/SickSafetyscanners.cpp
+++ b/src/SickSafetyscanners.cpp
@@ -39,7 +39,7 @@ namespace sick {
 
 SickSafetyscanners::SickSafetyscanners(
   packetReceivedCallbackFunction newPacketReceivedCallbackFunction,
-  sick::datastructure::CommSettings settings)
+  sick::datastructure::CommSettings* settings)
   : m_newPacketReceivedCallbackFunction(newPacketReceivedCallbackFunction)
 {
   ROS_INFO("Starting SickSafetyscanners");
@@ -47,7 +47,8 @@ SickSafetyscanners::SickSafetyscanners(
   m_async_udp_client_ptr = std::make_shared<sick::communication::AsyncUDPClient>(
     boost::bind(&SickSafetyscanners::processUDPPacket, this, _1),
     boost::ref(*m_io_service_ptr),
-    settings.getHostUdpPort());
+    settings->getHostUdpPort());
+  settings->setHostUdpPort(m_async_udp_client_ptr->get_local_port());  // Store which port was used, needed for data request from the laser
   m_packet_merger_ptr = std::make_shared<sick::data_processing::UDPPacketMerger>();
   ROS_INFO("Started SickSafetyscanners");
 }

--- a/src/SickSafetyscannersRos.cpp
+++ b/src/SickSafetyscannersRos.cpp
@@ -65,7 +65,7 @@ SickSafetyscannersRos::SickSafetyscannersRos()
     m_nh.advertiseService("field_data", &SickSafetyscannersRos::getFieldData, this);
 
   m_device = std::make_shared<sick::SickSafetyscanners>(
-    boost::bind(&SickSafetyscannersRos::receivedUDPPacket, this, _1), m_communication_settings);
+    boost::bind(&SickSafetyscannersRos::receivedUDPPacket, this, _1), &m_communication_settings);
   m_device->run();
   readTypeCodeSettings();
 
@@ -138,7 +138,7 @@ bool SickSafetyscannersRos::readParameters()
   }
   m_communication_settings.setHostIp(host_ip_adress);
 
-  int host_udp_port = 6060;
+  int host_udp_port = 0;
   if (!m_private_nh.getParam("host_udp_port", host_udp_port))
   {
     ROS_WARN("Using default host UDP Port: %i", host_udp_port);

--- a/src/cola2/ChangeCommSettingsCommand.cpp
+++ b/src/cola2/ChangeCommSettingsCommand.cpp
@@ -72,7 +72,7 @@ void ChangeCommSettingsCommand::writeDataToDataPtr(uint8_t*& data_ptr) const
   writeChannelToDataPtr(data_ptr);
   writeEnabledToDataPtr(data_ptr);
   writeEInterfaceTypeToDataPtr(data_ptr);
-  writeIPAdresstoDataPtr(data_ptr);
+  writeIPAddresstoDataPtr(data_ptr);
   writePortToDataPtr(data_ptr);
   writeFrequencyToDataPtr(data_ptr);
   writeStartAngleToDataPtr(data_ptr);
@@ -109,7 +109,7 @@ void ChangeCommSettingsCommand::writeEInterfaceTypeToDataPtr(uint8_t*& data_ptr)
   m_writer_ptr->writeuint8_tLittleEndian(data_ptr, m_settings.getEInterfaceType(), 5);
 }
 
-void ChangeCommSettingsCommand::writeIPAdresstoDataPtr(uint8_t*& data_ptr) const
+void ChangeCommSettingsCommand::writeIPAddresstoDataPtr(uint8_t*& data_ptr) const
 {
   m_writer_ptr->writeuint32_tLittleEndian(data_ptr, m_settings.getHostIp().to_ulong(), 8);
 }

--- a/src/communication/AsyncUDPClient.cpp
+++ b/src/communication/AsyncUDPClient.cpp
@@ -94,5 +94,13 @@ void AsyncUDPClient::runService()
   startReceive();
 }
 
+unsigned short AsyncUDPClient::get_local_port()
+{
+  if(m_socket_ptr){
+    return m_socket_ptr->local_endpoint().port();
+  }
+  return 0;
+}
+
 } // namespace communication
 } // namespace sick


### PR DESCRIPTION
This is a lower priority pull request than https://github.com/SICKAG/sick_safetyscanners/pull/2 and I won't have hardware to test against until Wednesday December 5.  This is untested, I will edit this message and update the PR when I test.  Feel free to edit and update this PR for this functionality.

I noticed an issue where when the node crashes, restarts, or is otherwise force closed, the specified port can be blocked on the host system.  There is otherwise nothing I am aware of that should stop the reconnect, but since the port is in use, the node cannot start.

The idea behind this pull request is to allow the default '0' port to be passed into the node.  This should choose the port from the ephemeral range and guarantee that it is available.  I don't believe most applications need a static port configuration, so any port should work.  If the user/application requires the port, then the parameter can be set and the behavior should be identical to existing behavior.