### PR TITLE
ROS-Console Wrapper for Core Library

### DIFF
--- a/include/sick_safetyscanners/SickSafetyscanners.h
+++ b/include/sick_safetyscanners/SickSafetyscanners.h
@@ -35,8 +35,6 @@
 #ifndef SICK_SAFETYSCANNERS_SICKSAFETYSCANNERS_H
 #define SICK_SAFETYSCANNERS_SICKSAFETYSCANNERS_H
 
-#include <ros/ros.h>
-
 #include <boost/function.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/thread.hpp>

--- a/include/sick_safetyscanners/cola2/Command.h
+++ b/include/sick_safetyscanners/cola2/Command.h
@@ -35,8 +35,6 @@
 #ifndef SICK_SAFETYSCANNERS_COLA2_COMMAND_H
 #define SICK_SAFETYSCANNERS_COLA2_COMMAND_H
 
-#include <ros/ros.h>
-
 #include <vector>
 
 #include <sick_safetyscanners/datastructure/PacketBuffer.h>

--- a/include/sick_safetyscanners/communication/AsyncTCPClient.h
+++ b/include/sick_safetyscanners/communication/AsyncTCPClient.h
@@ -35,8 +35,6 @@
 #ifndef SICK_SAFETYSCANNERS_COMMUNICATION_ASYNCTCPCLIENT_H
 #define SICK_SAFETYSCANNERS_COMMUNICATION_ASYNCTCPCLIENT_H
 
-#include <ros/ros.h>
-
 #include <functional>
 #include <iostream>
 #include <thread>

--- a/include/sick_safetyscanners/communication/AsyncUDPClient.h
+++ b/include/sick_safetyscanners/communication/AsyncUDPClient.h
@@ -35,8 +35,6 @@
 #ifndef SICK_SAFETYSCANNERS_COMMUNICATION_ASYNCUDPCLIENT_H
 #define SICK_SAFETYSCANNERS_COMMUNICATION_ASYNCUDPCLIENT_H
 
-#include <ros/ros.h>
-
 #include <functional>
 #include <iostream>
 

--- a/include/sick_safetyscanners/console/console_wrapper.h
+++ b/include/sick_safetyscanners/console/console_wrapper.h
@@ -1,0 +1,16 @@
+#ifndef SICK_SAFETYSCANNERS_CONSOLE_CONSOLEWRAPPER_H
+#define SICK_SAFETYSCANNERS_CONSOLE_CONSOLEWRAPPER_H
+
+#ifndef NO_ROS_CONSOLE
+
+#define ROS_INFO(...) 
+#define ROS_WARN(...)
+#define ROS_ERROR(...)
+
+#else
+
+#include <ros/console>
+
+#endif // NO_ROS_CONSOLE
+
+#endif // SICK_SAFETYSCANNERS_CONSOLE_CONSOLEWRAPPER_H

--- a/include/sick_safetyscanners/console/console_wrapper.h
+++ b/include/sick_safetyscanners/console/console_wrapper.h
@@ -1,15 +1,18 @@
 #ifndef SICK_SAFETYSCANNERS_CONSOLE_CONSOLEWRAPPER_H
 #define SICK_SAFETYSCANNERS_CONSOLE_CONSOLEWRAPPER_H
 
-#ifndef NO_ROS_CONSOLE
+#ifdef NO_ROS_CONSOLE
 
-#define ROS_INFO(...) 
-#define ROS_WARN(...)
-#define ROS_ERROR(...)
+#include <cstdio>
+
+// Turn ROS-Console commands into no-ops
+#define ROS_INFO(...) std::printf(__VA_ARGS__)
+#define ROS_WARN(...) std::printf(__VA_ARGS__)
+#define ROS_ERROR(...) std::fprintf(stderr, __VA_ARGS__)
 
 #else
 
-#include <ros/console>
+#include <ros/console.h>
 
 #endif // NO_ROS_CONSOLE
 

--- a/src/SickSafetyscanners.cpp
+++ b/src/SickSafetyscanners.cpp
@@ -34,6 +34,8 @@
 
 
 #include "sick_safetyscanners/SickSafetyscanners.h"
+#include <sick_safetyscanners/console/console_wrapper.h>
+
 
 namespace sick {
 

--- a/src/cola2/CloseSession.cpp
+++ b/src/cola2/CloseSession.cpp
@@ -37,6 +37,7 @@
 
 #include <sick_safetyscanners/cola2/Cola2Session.h>
 #include <sick_safetyscanners/cola2/Command.h>
+#include <ros/console.h>
 
 namespace sick {
 namespace cola2 {

--- a/src/cola2/CloseSession.cpp
+++ b/src/cola2/CloseSession.cpp
@@ -37,7 +37,7 @@
 
 #include <sick_safetyscanners/cola2/Cola2Session.h>
 #include <sick_safetyscanners/cola2/Command.h>
-#include <ros/console.h>
+#include <sick_safetyscanners/console/console_wrapper.h>
 
 namespace sick {
 namespace cola2 {

--- a/src/cola2/CreateSession.cpp
+++ b/src/cola2/CreateSession.cpp
@@ -36,7 +36,7 @@
 
 #include <sick_safetyscanners/cola2/Cola2Session.h>
 #include <sick_safetyscanners/cola2/Command.h>
-#include <ros/console.h>
+#include <sick_safetyscanners/console/console_wrapper.h>
 
 namespace sick {
 namespace cola2 {

--- a/src/cola2/CreateSession.cpp
+++ b/src/cola2/CreateSession.cpp
@@ -36,6 +36,7 @@
 
 #include <sick_safetyscanners/cola2/Cola2Session.h>
 #include <sick_safetyscanners/cola2/Command.h>
+#include <ros/console.h>
 
 namespace sick {
 namespace cola2 {

--- a/src/cola2/MethodCommand.cpp
+++ b/src/cola2/MethodCommand.cpp
@@ -37,6 +37,8 @@
 #include <sick_safetyscanners/cola2/Cola2Session.h>
 #include <sick_safetyscanners/cola2/Command.h>
 
+#include <ros/console.h>
+
 namespace sick {
 namespace cola2 {
 

--- a/src/cola2/MethodCommand.cpp
+++ b/src/cola2/MethodCommand.cpp
@@ -36,8 +36,7 @@
 
 #include <sick_safetyscanners/cola2/Cola2Session.h>
 #include <sick_safetyscanners/cola2/Command.h>
-
-#include <ros/console.h>
+#include <sick_safetyscanners/console/console_wrapper.h>
 
 namespace sick {
 namespace cola2 {

--- a/src/cola2/VariableCommand.cpp
+++ b/src/cola2/VariableCommand.cpp
@@ -36,7 +36,7 @@
 
 #include <sick_safetyscanners/cola2/Cola2Session.h>
 #include <sick_safetyscanners/cola2/Command.h>
-#include <ros/console.h>
+#include <sick_safetyscanners/console/console_wrapper.h>
 
 namespace sick {
 namespace cola2 {

--- a/src/cola2/VariableCommand.cpp
+++ b/src/cola2/VariableCommand.cpp
@@ -36,6 +36,7 @@
 
 #include <sick_safetyscanners/cola2/Cola2Session.h>
 #include <sick_safetyscanners/cola2/Command.h>
+#include <ros/console.h>
 
 namespace sick {
 namespace cola2 {

--- a/src/communication/AsyncTCPClient.cpp
+++ b/src/communication/AsyncTCPClient.cpp
@@ -33,6 +33,7 @@
 //----------------------------------------------------------------------
 
 #include <sick_safetyscanners/communication/AsyncTCPClient.h>
+#include <ros/console.h>
 
 namespace sick {
 namespace communication {

--- a/src/communication/AsyncTCPClient.cpp
+++ b/src/communication/AsyncTCPClient.cpp
@@ -33,7 +33,7 @@
 //----------------------------------------------------------------------
 
 #include <sick_safetyscanners/communication/AsyncTCPClient.h>
-#include <ros/console.h>
+#include <sick_safetyscanners/console/console_wrapper.h>
 
 namespace sick {
 namespace communication {

--- a/src/communication/AsyncUDPClient.cpp
+++ b/src/communication/AsyncUDPClient.cpp
@@ -34,6 +34,7 @@
 
 
 #include <sick_safetyscanners/communication/AsyncUDPClient.h>
+#include <sick_safetyscanners/console/console_wrapper.h>
 
 namespace sick {
 namespace communication {


### PR DESCRIPTION
Greetings! I think this is an excellent library and I can't thank you enough for going through the effort of developing and open-sourcing it.

I'm currently working on a project involving SICK products that does not also use ROS. The libraries you've developed are very nicely segregated into platform agnostic code with application classes & nodes in separate sections, so for the most part the ROS components live in a very small area at one end of the repo.

There is one breach of this separation, however, and that is the use of `rosconsole` macros throughout the core library. In the interest of making this library more friendly for people who are trying to build for platforms that do not have `rosconsole`, I propose the creation of some kind of console wrapper. This wrapper could be manipulated at build time to dispatch calls to ROS libraries for logging or to some other endpoint.

This PR is a down and dirty proof of concept that I'm using in testing. It creates a console_wrapper header that is controllable through a preprocessor directive `NO_ROS_CONSOLE`. If this is set, then calls go to the c standard library printing functions instead.

Let me know what you think. I'm more than willing to change things to accommodate the needs of this project.

Thanks,
Jon