### PR TITLE
Race Condition on Destruction

### DIFF
--- a/src/SickSafetyscanners.cpp
+++ b/src/SickSafetyscanners.cpp
@@ -57,6 +57,8 @@ SickSafetyscanners::SickSafetyscanners(
 
 SickSafetyscanners::~SickSafetyscanners()
 {
+  m_io_service_ptr->stop();
+  m_udp_client_thread_ptr->join();
   m_udp_client_thread_ptr.reset();
 }
 


### PR DESCRIPTION
Greetings,

I've been integrating this library into a larger application and noticed that every once in a while I'd get a segfault on closing out the driver.

Here's a backtrace from one particular instance:
```
#0  0x0000000000000000 in  ()
#1  0x0000000000823e90 in boost::asio::detail::scheduler_operation::destroy() ()
#2  0x0000000000823e45 in void boost::asio::detail::op_queue_access::destroy<boost::asio::detail::scheduler_operation>(boost::asio::detail::scheduler_operation*) ()
#3  0x0000000000823df1 in boost::asio::detail::op_queue<boost::asio::detail::scheduler_operation>::~op_queue() ()
#4  0x0000000000828183 in boost::asio::detail::scheduler::~scheduler() ()
#5  0x00000000008281e9 in boost::asio::detail::scheduler::~scheduler() ()
#6  0x0000000000435d2b in boost::asio::detail::service_registry::destroy(boost::asio::execution_context::service*) ()
#7  0x0000000000435cdc in boost::asio::detail::service_registry::destroy_services() ()
#8  0x0000000000435c08 in boost::asio::execution_context::destroy() ()
#9  0x0000000000435767 in boost::asio::execution_context::~execution_context() ()
#10 0x0000000000828695 in boost::asio::io_context::~io_context() ()
#11 0x0000000000828679 in void __gnu_cxx::new_allocator<boost::asio::io_context>::destroy<boost::asio::io_context>(boost::asio::io_context*) ()
#12 0x0000000000828618 in void std::allocator_traits<std::allocator<boost::asio::io_context> >::destroy<boost::asio::io_context>(std::allocator<boost::asio::io_context>&, boost::asio::io_context*) ()
#13 0x000000000082620c in std::_Sp_counted_ptr_inplace<boost::asio::io_context, std::allocator<boost::asio::io_context>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() ()
#14 0x00000000004328ec in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() ()
#15 0x000000000043289a in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() ()
#16 0x0000000000828889 in std::__shared_ptr<boost::asio::io_context, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() ()
#17 0x0000000000820df5 in std::shared_ptr<boost::asio::io_context>::~shared_ptr() ()
#18 0x000000000081f99b in sick::SickSafetyscanners::~SickSafetyscanners() ()
#19 0x000000000081f9d9 in sick::SickSafetyscanners::~SickSafetyscanners() ()
#20 0x0000000000432a6f in std::default_delete<sick::SickSafetyscanners>::operator()(sick::SickSafetyscanners*) const ()
#21 0x0000000000432760 in std::unique_ptr<sick::SickSafetyscanners, std::default_delete<sick::SickSafetyscanners> >::~unique_ptr() ()
#22 0x00000000004301ae in SickMicroScanCapture::~SickMicroScanCapture() ()
#23 0x000000000042f783 in main ()
```
I think this has to do with the order of shutdown between the IO thread and the io_service. In (limited) testing, the associated change seems to fix the problem. I stop the io_service which causes the `run()` function in the IO thread to return. Meanwhile in the main thread, I call `join` so the application waits for this process to conclude. Given that this class owns its own io_context, I think it's reasonable to invoke stop like this.