### PR TITLE
Fix issue with m_angle_offset.  Remove use_sick_angles

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,15 +143,14 @@ Returns all configured protective and warning fields for the sensor
 | host_udp_port             | Integer | 0 | | Host UDP Port.  Can be passed as an argument to the launch file.  Zero allows system chosen port. |
 | frame_id  | String | scan | | The frame name of the sensor message  |
 | skip    | Integer | 0 | | The number of scans to skip between each measured scan.  For a 25Hz laser, setting 'skip' to 0 makes it publish at 25Hz, 'skip' to 1 makes it publish at 12.5Hz. |
-| angle_start              | Double |  0.0| | Start angle of scan in radians, if both start and end angle are equal, all angels are regarded  |
-| angle_end                | Double | 0.0 | | End angle of scan in radians, if both start and end angle are equal, all angels are regarded  |
+| angle_start              | Double |  0.0| | Start angle of scan in radians, if both start and end angle are equal, all angels are regarded.  0° is at the front of the scanner. |
+| angle_end                | Double | 0.0 | | End angle of scan in radians, if both start and end angle are equal, all angels are regarded.  0° is at the front of the scanner. |
 | channel_enabled     | Boolean | true | | If the channel should be enabled  |
 | general_system_state  | Boolean | true | | If the general system state should be published  |
 | derived_settings      | Boolean | true | | If the derived settings should be published  |
 | measurement_data  | Boolean | true | | If the measurement data should be published  |
 | intrusion_data          | Boolean | true | | If the intrusion data should be published  |
 | application_io_data  | Boolean | true | | If the application IO data should be published  |
-| use_sick_angles | Boolean |  false | | If this flag is set, the predefined angles from SICK are used. If this flag is set to false an offset of -90° is added to the angles so that 0° is at the front of the scanner. |
 
 ## Creators
 

--- a/src/SickSafetyscannersRos.cpp
+++ b/src/SickSafetyscannersRos.cpp
@@ -172,11 +172,11 @@ bool SickSafetyscannersRos::readParameters()
 
   float angle_start;
   m_private_nh.getParam("angle_start", angle_start);
-  m_communication_settings.setStartAngle(sick::radToDeg(angle_start));
+  m_communication_settings.setStartAngle(sick::radToDeg(angle_start) - m_angle_offset);
 
   float angle_end;
   m_private_nh.getParam("angle_end", angle_end);
-  m_communication_settings.setEndAngle(sick::radToDeg(angle_end));
+  m_communication_settings.setEndAngle(sick::radToDeg(angle_end) - m_angle_offset);
 
   bool general_system_state;
   m_private_nh.getParam("general_system_state", general_system_state);
@@ -197,17 +197,6 @@ bool SickSafetyscannersRos::readParameters()
     general_system_state, derived_settings, measurement_data, intrusion_data, application_io_data);
 
   m_private_nh.getParam("frame_id", m_frame_id);
-
-  m_private_nh.getParam("use_sick_angles", m_use_sick_angles);
-
-  if (m_use_sick_angles)
-  {
-    m_angle_offset = 0;
-  }
-  else
-  {
-    m_angle_offset = -90.0;
-  }
 
   return true;
 }


### PR DESCRIPTION
The m_angle_offset was not used in initialization  Trying to use the new centered angles would prevent startup.

The use_sick_angles parameter can't be fully supported, so my recommendation is to remove it.  The dynamic reconfigure limits are forced into the -2.39 to +2.39 angle range and can't be updated.  If use_sick_angles is True, then dynamic reconfigure can't be used at all, or the angles just can't be set.

It would be nice to support the alternate angles and keep backwards compatibility, but it's probably not worth the difficulties in tracking down errors having two coordinate frames supported.