### PR TITLE
DeviceStatus Requests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ add_library(${PROJECT_NAME}_core
   src/data_processing/ParseDatagramHeader.cpp
   src/data_processing/ParseDerivedValues.cpp
   src/data_processing/ParseDeviceName.cpp
+  src/data_processing/ParseDeviceStatus.cpp
   src/data_processing/ParseFieldGeometryData.cpp
   src/data_processing/ParseFieldHeaderData.cpp
   src/data_processing/ParseGeneralSystemState.cpp
@@ -145,6 +146,7 @@ add_library(${PROJECT_NAME}_core
   src/datastructure/DataHeader.cpp
   src/datastructure/DatagramHeader.cpp
   src/datastructure/DerivedValues.cpp
+  src/datastructure/DeviceStatus.cpp
   src/datastructure/FieldData.cpp
   src/datastructure/GeneralSystemState.cpp
   src/datastructure/IntrusionData.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ add_library(${PROJECT_NAME}_core
   src/cola2/Command.cpp
   src/cola2/CreateSession.cpp
   src/cola2/DeviceNameVariableCommand.cpp
+  src/cola2/DeviceStatusVariableCommand.cpp
   src/cola2/FieldGeometryVariableCommand.cpp
   src/cola2/FieldHeaderVariableCommand.cpp
   src/cola2/MeasurementCurrentConfigVariableCommand.cpp

--- a/include/sick_safetyscanners/SickSafetyscanners.h
+++ b/include/sick_safetyscanners/SickSafetyscanners.h
@@ -62,6 +62,7 @@
 #include <sick_safetyscanners/cola2/MonitoringCaseTableHeaderVariableCommand.h>
 #include <sick_safetyscanners/cola2/MonitoringCaseVariableCommand.h>
 #include <sick_safetyscanners/cola2/TypeCodeVariableCommand.h>
+#include <sick_safetyscanners/cola2/DeviceStatusVariableCommand.h>
 
 namespace sick {
 
@@ -139,6 +140,9 @@ public:
   requestMonitoringCases(const sick::datastructure::CommSettings& settings,
                          std::vector<sick::datastructure::MonitoringCaseData>& monitoring_cases);
 
+  void requestDeviceStatus(const sick::datastructure::CommSettings& settings,
+                           sick::datastructure::DeviceStatus& device_status);
+
 
 private:
   packetReceivedCallbackFunction m_newPacketReceivedCallbackFunction;
@@ -167,6 +171,7 @@ private:
   void requestDeviceNameInColaSession(std::string& device_name);
   void requestMonitoringCaseDataInColaSession(
     std::vector<sick::datastructure::MonitoringCaseData>& monitoring_cases);
+  void requestDeviceStatusInColaSession(sick::datastructure::DeviceStatus& device_status);
 };
 
 } // namespace sick

--- a/include/sick_safetyscanners/cola2/DeviceStatusVariableCommand.h
+++ b/include/sick_safetyscanners/cola2/DeviceStatusVariableCommand.h
@@ -1,5 +1,39 @@
-#ifndef DEVICESTATUSVARIABLECOMMAND_H
-#define DEVICESTATUSVARIABLECOMMAND_H
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+
+/*!
+*  Copyright (C) 2018, SICK AG, Waldkirch
+*  Copyright (C) 2018, FZI Forschungszentrum Informatik, Karlsruhe, Germany
+*
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+*/
+
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!
+ * \file DeviceStatusVariableCommand.h
+ *
+ * \author  Jonathan Meyer <jmeyer1292@gmail.com>
+ * \date    2019-03-11
+ */
+//----------------------------------------------------------------------
+
+#ifndef SICK_SAFETY_SCANNERS_COLA2_DEVICESTATUSVARIABLECOMMAND_H
+#define SICK_SAFETY_SCANNERS_COLA2_DEVICESTATUSVARIABLECOMMAND_H
 
 #include <sick_safetyscanners/cola2/VariableCommand.h>
 #include <sick_safetyscanners/data_processing/ParseDeviceStatus.h>
@@ -9,7 +43,7 @@ namespace sick {
 namespace cola2 {
 
 /*!
- * \brief Command to read the field geometry from the sensor.
+ * \brief Command to read the device status registers from the sensor.
  */
 class DeviceStatusVariableCommand : public VariableCommand
 {
@@ -22,13 +56,11 @@ public:
   /*!
    * \brief Constructor of the command.
    *
-   * Takes the current cola2 session and a reference to the field data variable which will be
-   * written on execution. The index defines which field variable will be read. Depending on the
-   * sensor up to 128 variables can be defined.
+   * Takes the current cola2 session and a reference to the device status variable which will be
+   * written on execution.
    *
    * \param session The current cola2 session.
-   * \param field_data The field data reference which will be modified on execution.
-   * \param index The variable index in a range of [0, 127].
+   * \param field_data The device status reference which will be modified on execution.
    */
   DeviceStatusVariableCommand(Cola2Session& session,
                               datastructure::DeviceStatus& device_status);
@@ -67,4 +99,4 @@ private:
 } // namespace sick
 
 
-#endif // DEVICESTATUSVARIABLECOMMAND_H
+#endif // SICK_SAFETY_SCANNERS_COLA2_DEVICESTATUSVARIABLECOMMAND_H

--- a/include/sick_safetyscanners/cola2/DeviceStatusVariableCommand.h
+++ b/include/sick_safetyscanners/cola2/DeviceStatusVariableCommand.h
@@ -1,0 +1,70 @@
+#ifndef DEVICESTATUSVARIABLECOMMAND_H
+#define DEVICESTATUSVARIABLECOMMAND_H
+
+#include <sick_safetyscanners/cola2/VariableCommand.h>
+#include <sick_safetyscanners/data_processing/ParseDeviceStatus.h>
+#include <sick_safetyscanners/datastructure/DeviceStatus.h>
+
+namespace sick {
+namespace cola2 {
+
+/*!
+ * \brief Command to read the field geometry from the sensor.
+ */
+class DeviceStatusVariableCommand : public VariableCommand
+{
+public:
+  /*!
+   * \brief Typedef to reference the base class.
+   */
+  typedef sick::cola2::VariableCommand base_class;
+
+  /*!
+   * \brief Constructor of the command.
+   *
+   * Takes the current cola2 session and a reference to the field data variable which will be
+   * written on execution. The index defines which field variable will be read. Depending on the
+   * sensor up to 128 variables can be defined.
+   *
+   * \param session The current cola2 session.
+   * \param field_data The field data reference which will be modified on execution.
+   * \param index The variable index in a range of [0, 127].
+   */
+  DeviceStatusVariableCommand(Cola2Session& session,
+                              datastructure::DeviceStatus& device_status);
+
+  /*!
+   * \brief Adds the data to the telegram.
+   *
+   * \param telegram The telegram which will be modified by the data.
+   */
+  void addTelegramData(sick::datastructure::PacketBuffer::VectorBuffer& telegram) const;
+
+  /*!
+   * \brief Returns if the command can be executed without a session ID. Will return false for most
+   * commands except the commands to establish a connection.
+   *
+   * \returns If the command needs a session ID to be executed.
+   */
+  bool canBeExecutedWithoutSessionID() const;
+
+  /*!
+   * \brief Processes the return from the sensor.
+   *
+   * \returns If processing of the returned data was successful.
+   */
+  bool processReply();
+
+
+private:
+  std::shared_ptr<sick::data_processing::ReadWriteHelper> m_writer_ptr;
+  std::shared_ptr<sick::data_processing::ParseDeviceStatus> m_device_status_parser_ptr;
+
+  sick::datastructure::DeviceStatus& m_device_status;
+};
+
+} // namespace cola2
+} // namespace sick
+
+
+#endif // DEVICESTATUSVARIABLECOMMAND_H

--- a/include/sick_safetyscanners/data_processing/ParseDeviceStatus.h
+++ b/include/sick_safetyscanners/data_processing/ParseDeviceStatus.h
@@ -1,6 +1,39 @@
-#ifndef PARSEDEVICESTATUS_H
-#define PARSEDEVICESTATUS_H
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
 
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+
+/*!
+*  Copyright (C) 2018, SICK AG, Waldkirch
+*  Copyright (C) 2018, FZI Forschungszentrum Informatik, Karlsruhe, Germany
+*
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+*/
+
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!
+ * \file DeviceStatusVariableCommand.h
+ *
+ * \author  Jonathan Meyer <jmeyer1292@gmail.com>
+ * \date    2019-03-11
+ */
+//----------------------------------------------------------------------
+
+#ifndef SICK_SAFETYSCANNERS_DATA_PROCESSING_PARSEDEVICESTATUS_H
+#define SICK_SAFETYSCANNERS_DATA_PROCESSING_PARSEDEVICESTATUS_H
 
 #include <sick_safetyscanners/datastructure/Data.h>
 #include <sick_safetyscanners/datastructure/PacketBuffer.h>
@@ -12,9 +45,8 @@ namespace sick {
 
 namespace data_processing {
 
-
 /*!
- * \brief Parser to read the type code of a tcp sequence.
+ * \brief Parser to read the device status from a tcp sequence.
  */
 class ParseDeviceStatus
 {
@@ -25,10 +57,10 @@ public:
   ParseDeviceStatus();
 
   /*!
-   * \brief Parses a tcp sequence to read the type code of the sensor.
+   * \brief Parses a tcp sequence to read the device status of the sensor.
    *
    * \param buffer The incoming tcp sequence.
-   * \param type_code Reference to the type code, which will be written while parsing.
+   * \param type_code Reference to the device status, which will be written while parsing.
    *
    * \returns If parsing was successful.
    */
@@ -42,4 +74,4 @@ private:
 }
 }
 
-#endif // PARSEDEVICESTATUS_H
+#endif // SICK_SAFETYSCANNERS_DATA_PROCESSING_PARSEDEVICESTATUS_H

--- a/include/sick_safetyscanners/data_processing/ParseDeviceStatus.h
+++ b/include/sick_safetyscanners/data_processing/ParseDeviceStatus.h
@@ -1,0 +1,95 @@
+#ifndef PARSEDEVICESTATUS_H
+#define PARSEDEVICESTATUS_H
+
+
+#include <sick_safetyscanners/datastructure/Data.h>
+#include <sick_safetyscanners/datastructure/PacketBuffer.h>
+#include <sick_safetyscanners/datastructure/DeviceStatus.h>
+
+#include <sick_safetyscanners/data_processing/ReadWriteHelper.h>
+
+namespace sick {
+
+namespace data_processing {
+
+
+/*!
+ * \brief Parser to read the type code of a tcp sequence.
+ */
+class ParseDeviceStatus
+{
+public:
+  /*!
+   * \brief Constructor of the parser.
+   */
+  ParseDeviceStatus();
+
+  /*!
+   * \brief Parses a tcp sequence to read the type code of the sensor.
+   *
+   * \param buffer The incoming tcp sequence.
+   * \param type_code Reference to the type code, which will be written while parsing.
+   *
+   * \returns If parsing was successful.
+   */
+  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                        datastructure::DeviceStatus& device_status) const;
+
+private:
+  std::shared_ptr<sick::data_processing::ReadWriteHelper> m_reader_ptr;
+
+  void setVersionIndicatorInDataHeader(const uint8_t*& data_ptr,
+                                       datastructure::DataHeader& data_header) const;
+  void setMajorVersionInDataHeader(const uint8_t*& data_ptr,
+                                   datastructure::DataHeader& data_header) const;
+  void setMinorVersionInDataHeader(const uint8_t*& data_ptr,
+                                   datastructure::DataHeader& data_header) const;
+  void setVersionReleaseInDataHeader(const uint8_t*& data_ptr,
+                                     datastructure::DataHeader& data_header) const;
+  void setSerialNumberOfDeviceInDataHeader(const uint8_t*& data_ptr,
+                                           datastructure::DataHeader& data_header) const;
+  void setSerialNumberOfSystemPlugInDataHeader(const uint8_t*& data_ptr,
+                                               datastructure::DataHeader& data_header) const;
+  void setChannelNumberInDataHeader(const uint8_t*& data_ptr,
+                                    datastructure::DataHeader& data_header) const;
+  void setSequenceNumberInDataHeader(const uint8_t*& data_ptr,
+                                     datastructure::DataHeader& data_header) const;
+  void setScanNumberInDataHeader(const uint8_t*& data_ptr,
+                                 datastructure::DataHeader& data_header) const;
+  void setTimestampDateInDataHeader(const uint8_t*& data_ptr,
+                                    datastructure::DataHeader& data_header) const;
+  void setTimestampTimeInDataHeader(const uint8_t*& data_ptr,
+                                    datastructure::DataHeader& data_header) const;
+  void setGeneralSystemStateBlockOffsetInDataHeader(const uint8_t*& data_ptr,
+                                                    datastructure::DataHeader& data_header) const;
+  void setGeneralSystemStateBlockSizeInDataHeader(const uint8_t*& data_ptr,
+                                                  datastructure::DataHeader& data_header) const;
+  void setDerivedValuesBlockOffsetInDataHeader(const uint8_t*& data_ptr,
+                                               datastructure::DataHeader& data_header) const;
+  void setDerivedValuesBlockSizeInDataHeader(const uint8_t*& data_ptr,
+                                             datastructure::DataHeader& data_header) const;
+  void setMeasurementDataBlockOffsetInDataHeader(const uint8_t*& data_ptr,
+                                                 datastructure::DataHeader& data_header) const;
+  void setMeasurementDataBlockSizeInDataHeader(const uint8_t*& data_ptr,
+                                               datastructure::DataHeader& data_header) const;
+  void setIntrusionDataBlockOffsetInDataHeader(const uint8_t*& data_ptr,
+                                               datastructure::DataHeader& data_header) const;
+  void setIntrusionDataBlockSizeInDataHeader(const uint8_t*& data_ptr,
+                                             datastructure::DataHeader& data_header) const;
+  void setApplicationDataBlockOffsetInDataHeader(const uint8_t*& data_ptr,
+                                                 datastructure::DataHeader& data_header) const;
+  void setApplicationDataBlockSizeInDataHeader(const uint8_t*& data_ptr,
+                                               datastructure::DataHeader& data_header) const;
+  void setDataInDataHeader(const uint8_t*& data_ptr, datastructure::DataHeader& data_header) const;
+  void setVersionInDataHeader(const uint8_t*& data_ptr,
+                              datastructure::DataHeader& data_header) const;
+  void setScanHeaderInDataHeader(const uint8_t*& data_ptr,
+                                 datastructure::DataHeader& data_header) const;
+  void setDataBlocksInDataHeader(const uint8_t*& data_ptr,
+                                 datastructure::DataHeader& data_header) const;
+};
+
+}
+}
+
+#endif // PARSEDEVICESTATUS_H

--- a/include/sick_safetyscanners/data_processing/ParseDeviceStatus.h
+++ b/include/sick_safetyscanners/data_processing/ParseDeviceStatus.h
@@ -37,56 +37,6 @@ public:
 
 private:
   std::shared_ptr<sick::data_processing::ReadWriteHelper> m_reader_ptr;
-
-  void setVersionIndicatorInDataHeader(const uint8_t*& data_ptr,
-                                       datastructure::DataHeader& data_header) const;
-  void setMajorVersionInDataHeader(const uint8_t*& data_ptr,
-                                   datastructure::DataHeader& data_header) const;
-  void setMinorVersionInDataHeader(const uint8_t*& data_ptr,
-                                   datastructure::DataHeader& data_header) const;
-  void setVersionReleaseInDataHeader(const uint8_t*& data_ptr,
-                                     datastructure::DataHeader& data_header) const;
-  void setSerialNumberOfDeviceInDataHeader(const uint8_t*& data_ptr,
-                                           datastructure::DataHeader& data_header) const;
-  void setSerialNumberOfSystemPlugInDataHeader(const uint8_t*& data_ptr,
-                                               datastructure::DataHeader& data_header) const;
-  void setChannelNumberInDataHeader(const uint8_t*& data_ptr,
-                                    datastructure::DataHeader& data_header) const;
-  void setSequenceNumberInDataHeader(const uint8_t*& data_ptr,
-                                     datastructure::DataHeader& data_header) const;
-  void setScanNumberInDataHeader(const uint8_t*& data_ptr,
-                                 datastructure::DataHeader& data_header) const;
-  void setTimestampDateInDataHeader(const uint8_t*& data_ptr,
-                                    datastructure::DataHeader& data_header) const;
-  void setTimestampTimeInDataHeader(const uint8_t*& data_ptr,
-                                    datastructure::DataHeader& data_header) const;
-  void setGeneralSystemStateBlockOffsetInDataHeader(const uint8_t*& data_ptr,
-                                                    datastructure::DataHeader& data_header) const;
-  void setGeneralSystemStateBlockSizeInDataHeader(const uint8_t*& data_ptr,
-                                                  datastructure::DataHeader& data_header) const;
-  void setDerivedValuesBlockOffsetInDataHeader(const uint8_t*& data_ptr,
-                                               datastructure::DataHeader& data_header) const;
-  void setDerivedValuesBlockSizeInDataHeader(const uint8_t*& data_ptr,
-                                             datastructure::DataHeader& data_header) const;
-  void setMeasurementDataBlockOffsetInDataHeader(const uint8_t*& data_ptr,
-                                                 datastructure::DataHeader& data_header) const;
-  void setMeasurementDataBlockSizeInDataHeader(const uint8_t*& data_ptr,
-                                               datastructure::DataHeader& data_header) const;
-  void setIntrusionDataBlockOffsetInDataHeader(const uint8_t*& data_ptr,
-                                               datastructure::DataHeader& data_header) const;
-  void setIntrusionDataBlockSizeInDataHeader(const uint8_t*& data_ptr,
-                                             datastructure::DataHeader& data_header) const;
-  void setApplicationDataBlockOffsetInDataHeader(const uint8_t*& data_ptr,
-                                                 datastructure::DataHeader& data_header) const;
-  void setApplicationDataBlockSizeInDataHeader(const uint8_t*& data_ptr,
-                                               datastructure::DataHeader& data_header) const;
-  void setDataInDataHeader(const uint8_t*& data_ptr, datastructure::DataHeader& data_header) const;
-  void setVersionInDataHeader(const uint8_t*& data_ptr,
-                              datastructure::DataHeader& data_header) const;
-  void setScanHeaderInDataHeader(const uint8_t*& data_ptr,
-                                 datastructure::DataHeader& data_header) const;
-  void setDataBlocksInDataHeader(const uint8_t*& data_ptr,
-                                 datastructure::DataHeader& data_header) const;
 };
 
 }

--- a/include/sick_safetyscanners/datastructure/DeviceStatus.h
+++ b/include/sick_safetyscanners/datastructure/DeviceStatus.h
@@ -1,0 +1,81 @@
+#ifndef DEVICESTATUS_H
+#define DEVICESTATUS_H
+
+#include <iostream>
+#include <vector>
+
+namespace sick {
+namespace datastructure {
+
+/*!
+ * \brief Field data for warning and protective fields.
+ */
+class DeviceStatus
+{
+public:
+  /*!
+   * \brief The constructor of the field data.
+   */
+  DeviceStatus();
+
+  uint8_t getVersionIndicator() const;
+  void setVersionIndicator(uint8_t version_indicator);
+
+  uint8_t getVersionMajorVersion() const;
+  void setVersionMajorVersion(uint8_t major_version);
+
+  uint8_t getVersionMinorVersion() const;
+  void setVersionMinorVersion(uint8_t minor_version);
+
+  uint8_t getVersionRelease() const;
+  void setVersionRelease(uint8_t version_release);
+
+  uint8_t getDeviceState() const;
+  void setDeviceState(uint8_t device_state);
+
+  uint8_t getConfigState() const;
+  void setConfigState(uint8_t config_state);
+
+  uint8_t getApplicationState() const;
+  void setApplicationState(uint8_t application_state);
+
+  uint32_t getPowerOnCount() const;
+  void setPowerOnCount(uint32_t power_on_count);
+
+  uint32_t getCurrentTimeTime() const;
+  void setCurrentTimeTime(uint32_t time_time);
+
+  uint16_t getCurrentTimeDate() const;
+  void setCurrentTimeDate(uint16_t time_date);
+
+  uint32_t getErrorInfoCode() const;
+  void setErrorInfoCode(uint32_t error_info_code);
+
+  uint32_t getErrorInfoTime() const;
+  void setErrorInfoTime(uint32_t error_info_time);
+
+  uint16_t getErrorInfoDate() const;
+  void setErrorInfoDate(uint16_t error_info_date);
+
+private:
+  uint8_t m_version_indicator;
+  uint8_t m_version_major_version;
+  uint8_t m_version_minor_version;
+  uint8_t m_version_release;
+  uint8_t m_device_state;
+  uint8_t m_config_state;
+  uint8_t m_application_state;
+  uint32_t m_power_on_count;
+  uint32_t m_time_time;
+  uint16_t m_time_date;
+  uint32_t m_error_info_code;
+  uint32_t m_error_info_time;
+  uint16_t m_error_info_date;
+};
+
+
+} // namespace datastructure
+} // namespace sick
+
+
+#endif // DEVICESTATUS_H

--- a/include/sick_safetyscanners/datastructure/DeviceStatus.h
+++ b/include/sick_safetyscanners/datastructure/DeviceStatus.h
@@ -1,14 +1,47 @@
-#ifndef DEVICESTATUS_H
-#define DEVICESTATUS_H
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
 
-#include <iostream>
-#include <vector>
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+
+/*!
+*  Copyright (C) 2018, SICK AG, Waldkirch
+*  Copyright (C) 2018, FZI Forschungszentrum Informatik, Karlsruhe, Germany
+*
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+*/
+
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!
+ * \file DeviceStatusVariableCommand.h
+ *
+ * \author  Jonathan Meyer <jmeyer1292@gmail.com>
+ * \date    2019-03-11
+ */
+//----------------------------------------------------------------------
+
+#ifndef SICK_SAFETYSCANNERS_DATASTRUCTURE_DEVICESTATUS_H
+#define SICK_SAFETYSCANNERS_DATASTRUCTURE_DEVICESTATUS_H
+
+#include <cstdint>
 
 namespace sick {
 namespace datastructure {
 
 /*!
- * \brief Field data for warning and protective fields.
+ * \brief Status information for the given sensor such as time of day and version information.
  */
 class DeviceStatus
 {
@@ -78,4 +111,4 @@ private:
 } // namespace sick
 
 
-#endif // DEVICESTATUS_H
+#endif // SICK_SAFETYSCANNERS_DATASTRUCTURE_DEVICESTATUS_H

--- a/src/SickSafetyscanners.cpp
+++ b/src/SickSafetyscanners.cpp
@@ -126,6 +126,16 @@ void SickSafetyscanners::requestMonitoringCases(
   stopTCPConnection();
 }
 
+void SickSafetyscanners::requestDeviceStatus(const datastructure::CommSettings& settings,
+                                             datastructure::DeviceStatus& device_status)
+{
+  startTCPConnection(settings);
+
+  requestDeviceStatusInColaSession(device_status);
+
+  stopTCPConnection();
+}
+
 void SickSafetyscanners::requestDeviceName(const datastructure::CommSettings& settings,
                                            std::string& device_name)
 {
@@ -225,6 +235,14 @@ void SickSafetyscanners::requestMonitoringCaseDataInColaSession(
       break; // skip other requests after first invalid
     }
   }
+}
+
+void SickSafetyscanners::requestDeviceStatusInColaSession(datastructure::DeviceStatus& device_status)
+{
+  sick::cola2::Cola2Session::CommandPtr command_ptr =
+    std::make_shared<sick::cola2::DeviceStatusVariableCommand>(boost::ref(*m_session_ptr),
+                                                               device_status);
+  m_session_ptr->executeCommand(command_ptr);
 }
 
 void SickSafetyscanners::requestDeviceNameInColaSession(std::string& device_name)

--- a/src/cola2/DeviceStatusVariableCommand.cpp
+++ b/src/cola2/DeviceStatusVariableCommand.cpp
@@ -1,0 +1,42 @@
+
+#include <sick_safetyscanners/cola2/DeviceStatusVariableCommand.h>
+
+#include <sick_safetyscanners/cola2/Cola2Session.h>
+#include <sick_safetyscanners/cola2/Command.h>
+
+namespace sick {
+namespace cola2 {
+
+DeviceStatusVariableCommand::DeviceStatusVariableCommand(Cola2Session &session, datastructure::DeviceStatus &device_status)
+  : VariableCommand(session, 23)
+  , m_device_status(device_status)
+{
+  m_writer_ptr             = std::make_shared<sick::data_processing::ReadWriteHelper>();
+  m_device_status_parser_ptr = std::make_shared<sick::data_processing::ParseDeviceStatus>();
+}
+
+void DeviceStatusVariableCommand::addTelegramData(
+  sick::datastructure::PacketBuffer::VectorBuffer& telegram) const
+{
+  base_class::addTelegramData(telegram);
+}
+
+bool DeviceStatusVariableCommand::canBeExecutedWithoutSessionID() const
+{
+  return true;
+}
+
+bool DeviceStatusVariableCommand::processReply()
+{
+  if (!base_class::processReply())
+  {
+    return false;
+  }
+
+  m_device_status_parser_ptr->parseTCPSequence(getDataVector(), m_device_status);
+
+  return true;
+}
+
+} // namespace cola2
+} // namespace sick

--- a/src/data_processing/ParseDeviceStatus.cpp
+++ b/src/data_processing/ParseDeviceStatus.cpp
@@ -1,0 +1,40 @@
+#include <sick_safetyscanners/data_processing/ParseDeviceStatus.h>
+#include <sick_safetyscanners/cola2/Command.h>
+
+namespace sick {
+namespace data_processing {
+
+ParseDeviceStatus::ParseDeviceStatus()
+{
+  m_reader_ptr = std::make_shared<sick::data_processing::ReadWriteHelper>();
+}
+
+
+bool ParseDeviceStatus::parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                                         datastructure::DeviceStatus& device_status) const
+{
+  const uint8_t* data_ptr(buffer.getBuffer().data());
+
+  device_status.setVersionIndicator(m_reader_ptr->readuint8_tLittleEndian(data_ptr, 0));
+  device_status.setVersionMajorVersion(m_reader_ptr->readuint8_tLittleEndian(data_ptr, 1));
+  device_status.setVersionMinorVersion(m_reader_ptr->readuint8_tLittleEndian(data_ptr, 2));
+  device_status.setVersionRelease(m_reader_ptr->readuint8_tLittleEndian(data_ptr, 3));
+
+  device_status.setDeviceState(m_reader_ptr->readuint8_tLittleEndian(data_ptr, 4));
+  device_status.setConfigState(m_reader_ptr->readuint8_tLittleEndian(data_ptr, 5));
+  device_status.setApplicationState(m_reader_ptr->readuint8_tLittleEndian(data_ptr, 6));
+
+  device_status.setPowerOnCount(m_reader_ptr->readuint32_tLittleEndian(data_ptr, 12));
+  device_status.setCurrentTimeTime(m_reader_ptr->readuint32_tLittleEndian(data_ptr, 16));
+  device_status.setCurrentTimeDate(m_reader_ptr->readuint16_tLittleEndian(data_ptr, 20));
+
+  device_status.setErrorInfoCode(m_reader_ptr->readuint32_tLittleEndian(data_ptr, 24));
+  device_status.setErrorInfoTime(m_reader_ptr->readuint32_tLittleEndian(data_ptr, 52));
+  device_status.setErrorInfoDate(m_reader_ptr->readuint16_tLittleEndian(data_ptr, 56));
+
+  return true;
+}
+
+
+} // namespace data_processing
+} // namespace sick

--- a/src/datastructure/DeviceStatus.cpp
+++ b/src/datastructure/DeviceStatus.cpp
@@ -1,0 +1,3 @@
+#include <sick_safetyscanners/datastructure/DeviceStatus.h>
+
+// TODO

--- a/src/datastructure/DeviceStatus.cpp
+++ b/src/datastructure/DeviceStatus.cpp
@@ -1,3 +1,82 @@
 #include <sick_safetyscanners/datastructure/DeviceStatus.h>
 
 // TODO
+namespace sick {
+namespace datastructure {
+
+DeviceStatus::DeviceStatus() {}
+uint8_t DeviceStatus::getVersionIndicator() const {
+  return m_version_indicator;
+}
+void DeviceStatus::setVersionIndicator(uint8_t version_indicator) {
+  m_version_indicator = version_indicator;
+}
+
+uint8_t DeviceStatus::getVersionMajorVersion() const {
+  return m_version_major_version;
+}
+void DeviceStatus::setVersionMajorVersion(uint8_t major_version) {
+  m_version_major_version = major_version;
+}
+
+uint8_t DeviceStatus::getVersionMinorVersion() const {
+  return m_version_minor_version;
+}
+void DeviceStatus::setVersionMinorVersion(uint8_t minor_version) {
+  m_version_minor_version = minor_version;
+}
+
+uint8_t DeviceStatus::getVersionRelease() const { return m_version_release; }
+void DeviceStatus::setVersionRelease(uint8_t version_release) {
+  m_version_release = version_release;
+}
+
+uint8_t DeviceStatus::getDeviceState() const { return m_device_state; }
+void DeviceStatus::setDeviceState(uint8_t device_state) {
+  m_device_state = device_state;
+}
+
+uint8_t DeviceStatus::getConfigState() const { return m_config_state; }
+void DeviceStatus::setConfigState(uint8_t config_state) {
+  m_config_state = config_state;
+}
+
+uint8_t DeviceStatus::getApplicationState() const {
+  return m_application_state;
+}
+void DeviceStatus::setApplicationState(uint8_t application_state) {
+  m_application_state = application_state;
+}
+
+uint32_t DeviceStatus::getPowerOnCount() const { return m_power_on_count; }
+void DeviceStatus::setPowerOnCount(uint32_t power_on_count) {
+  m_power_on_count = power_on_count;
+}
+
+uint32_t DeviceStatus::getCurrentTimeTime() const { return m_time_time; }
+void DeviceStatus::setCurrentTimeTime(uint32_t time_time) {
+  m_time_time = time_time;
+}
+
+uint16_t DeviceStatus::getCurrentTimeDate() const { return m_time_date; }
+void DeviceStatus::setCurrentTimeDate(uint16_t time_date) {
+  m_time_date = time_date;
+}
+
+uint32_t DeviceStatus::getErrorInfoCode() const { return m_error_info_code; }
+void DeviceStatus::setErrorInfoCode(uint32_t error_info_code) {
+  m_error_info_code = error_info_code;
+}
+
+uint32_t DeviceStatus::getErrorInfoTime() const { return m_error_info_time; }
+void DeviceStatus::setErrorInfoTime(uint32_t error_info_time) {
+  m_error_info_time = error_info_time;
+}
+
+uint16_t DeviceStatus::getErrorInfoDate() const { return m_error_info_date; }
+void DeviceStatus::setErrorInfoDate(uint16_t error_info_date) {
+  m_error_info_date = error_info_date;
+}
+
+}  // namespace datastructure
+}  // namespace sick


### PR DESCRIPTION
Hey @puck-fzi!

I'm back to working on the SICK integration into my robot and I'm trying to automatically estimate the time offset between my computer's steady clock and the sensor's own clock so that I can better synchronize the SICK with other sensors.

To this end, I've implemented the `device status` command from the COLA protocol so that I can ping the sensors system time directly. 

This PR is not in a final state as there are many style related things to clean up, but I wanted to gauge your opinion on accepting this contribution.

The other issue is this: I want to be able to send a request to the scanner and have it respond as quickly as possible so that we get the best estimate for what the UDP packets will see for network transmission delay. This means that I want some code that looks like this:
```c++
auto start_time = std::chrono::steady_clock::now();
requestDeviceStatus(device_status);
auto end_time = std::chrono::steady_clock::now();
```

The current command architecture starts a new cola session (and thus TCP connection) on every request which skews the estimated delay by a lot. Would you be opposed to a dedicated function in `Sicksafetyscanners` that attempts to compute the offset during a single session?

Thanks,
Jon