### PR TITLE
Issue with time_offset on startup and support REP 117

### DIFF
--- a/src/SickSafetyscannersRos.cpp
+++ b/src/SickSafetyscannersRos.cpp
@@ -363,6 +363,12 @@ SickSafetyscannersRos::createLaserScanMessage(const sick::datastructure::Data& d
     const sick::datastructure::ScanPoint scan_point = scan_points.at(i);
     scan.ranges[i]                                  = static_cast<float>(scan_point.getDistance()) *
                      data.getDerivedValuesPtr()->getMultiplicationFactor() * 1e-3; // mm -> m
+    // Set values close to/greater than max range to infinity according to REP 117
+    // https://www.ros.org/reps/rep-0117.html
+    if (scan.ranges[i] >= (0.999 * m_range_max))
+    {
+      scan.ranges[i] = std::numeric_limits<double>::infinity();
+    }
     scan.intensities[i] = static_cast<float>(scan_point.getReflectivity());
   }
 

--- a/src/SickSafetyscannersRos.cpp
+++ b/src/SickSafetyscannersRos.cpp
@@ -215,6 +215,8 @@ bool SickSafetyscannersRos::readParameters()
     m_communication_settings.setEndAngle(sick::radToDeg(angle_end) - m_angle_offset);
   }
 
+  m_private_nh.getParam("time_offset", m_time_offset);
+
   bool general_system_state;
   m_private_nh.getParam("general_system_state", general_system_state);
 


### PR DESCRIPTION
A few small fixes:

The first is that in some situations m_time_offset would not be set from the parameter server (depends on the dynamic reconfigure callbacks, etc).  This ensures that it sets every time and initializes correctly.

The second is that sometimes the scanner reports ambiguous values at or near the max range, these might be fictitious and could cause issues for some mapping and obstacle avoidance applications.  Setting these values to +Inf is an accepted way of still using these values to clear occupancy grids while not knowing definitively if there's an object at the end of the ray.