### PR TITLE
Quick and dirty fix to exit if no tcp connection is reached

### DIFF
--- a/src/communication/AsyncTCPClient.cpp
+++ b/src/communication/AsyncTCPClient.cpp
@@ -93,6 +93,7 @@ void AsyncTCPClient::doConnect()
     if (ec != boost::system::errc::success)
     {
       ROS_ERROR("TCP error code: %i", ec.value());
+      exit(-1);
     }
     else
     {


### PR DESCRIPTION
Hello,

can we merge this Branch ? For us it is very important that we have some handling, when the connection couldn't be established.

I did it with rethrow the exception but this solution is also ok

For the use case it is important, that when no scanner is reachable the node reacts to this. Only then the highlevel Application can decide if it want to restart the node for example.
