### PR TITLE
Use system tool to ping connection of a sick scanner

### DIFF
--- a/include/sick_safetyscanners/SickSafetyscannersRos.h
+++ b/include/sick_safetyscanners/SickSafetyscannersRos.h
@@ -220,6 +220,8 @@ private:
 
   bool getFieldData(sick_safetyscanners::FieldData::Request& req,
                     sick_safetyscanners::FieldData::Response& res);
+  std::function<void(void)> watchdog();
+  void run(const int duration);
 };
 
 } // namespace sick


### PR DESCRIPTION
## Context
In some applications, we need to restart the scanners (from a PLC) without necessary restart the unit that run ROS driver.  

## Actual Behavior
If we restart the scanners while the ROS driver is running, the actual behavior is that no data are output because there is no way to check if the connection is dropped so the node is getting stuck. This is explained here : #79, #95.

## Feature Behavior
From #79, @puck-fzi  gave some options to implement a watchdog, so i tried to implement the "easier" one but not the best i concede. However, in our case its working! 

So i used the system tool to ping the IP address of the scanner in a separate thread and check if a packet is received or not. If its not the case, shutdown the node and after that you can respawn with specific tag in a launch file or maybe with another way. The objective here is to check for a disconnection while the ROS driver is running. 

Finally, i dont know if this pull could be merged to the principal branch but it could be useful for people who had the same issue.

Thank you!