### PR TITLE
Add option to override the measured intensities by the reflector bit / median bit information 

### DIFF
--- a/config/SickSafetyscannersConfiguration.cfg
+++ b/config/SickSafetyscannersConfiguration.cfg
@@ -29,7 +29,14 @@ gen.add("derived_settings", bool_t, 8, "Publish derived settings",True)
 gen.add("measurement_data", bool_t, 8, "Publish measurement data",True)
 gen.add("intrusion_data", bool_t, 8, "Publish intrusion data",True)
 gen.add("application_io_data", bool_t, 8, "Publish application io data",True)
+gen.add("reflector_intensity", double_t, 0, "intensity that is used with intensity_mode",255, 0, 255)
 
+intensity_mode_enum = gen.enum([ gen.const("Default",           int_t, 0, "The default behavior, intensity from the laser is used."),
+                                 gen.const("Reflector_Status",  int_t, 1, "When the reflector status of a scan point is set to True, the intensity is set to reflector_intensity."),
+                                 gen.const("Reflector_Median",  int_t, 2, "When the reflector median of a scan point is set to True, the intensity is set to reflector_intensity.")],
+                                "Enum to set the intensity mode")
+
+gen.add("intensity_mode", int_t, 0, "Spezifies how the intensities in the scan message should be filled", 0, 0, 2, edit_method=intensity_mode_enum)
 
 
 exit(gen.generate(PACKAGE, "dynamic_reconfigure_node", "SickSafetyscannersConfiguration"))

--- a/include/sick_safetyscanners/SickSafetyscannersRos.h
+++ b/include/sick_safetyscanners/SickSafetyscannersRos.h
@@ -165,6 +165,9 @@ private:
   float m_angle_offset;
   bool m_use_pers_conf;
 
+  double m_reflector_intensity = 255.0;
+  int m_intensity_mode = 0;
+
   /*!
    * @brief Reads and verifies the ROS parameters.
    * @return True if successful.

--- a/launch/sick_safetyscanners.launch
+++ b/launch/sick_safetyscanners.launch
@@ -16,7 +16,9 @@
   <arg name="measurement_data"      default="True" />
   <arg name="intrusion_data"        default="True" />
   <arg name="application_io_data"   default="True" />
-  <arg name="use_persistent_config"   default="False" />
+  <arg name="use_persistent_config" default="False" />
+  <arg name="reflector_intensity"   default="255" />
+  <arg name="intensity_mode"        default="0" />
 
   <!-- Launch Sick SickSafetyscanners Ros Driver Node -->
   <node pkg="sick_safetyscanners" type="sick_safetyscanners_node" name="sick_safetyscanners" output="screen" ns="sick_safetyscanners">
@@ -38,6 +40,8 @@
      <param name="intrusion_data"         type="bool"   value="$(arg intrusion_data)" />
      <param name="application_io_data"    type="bool"   value="$(arg application_io_data)" />
      <param name="use_persistent_config"  type="bool"   value="$(arg use_persistent_config)" />
+     <param name="reflector_intensity"    type="double" value="$(arg reflector_intensity)" />
+     <param name="intensity_mode"         type="int"    value="$(arg intensity_mode)" />
   </node>
 
 

--- a/msg/ExtendedLaserScanMsg.msg
+++ b/msg/ExtendedLaserScanMsg.msg
@@ -1,5 +1,5 @@
 sensor_msgs/LaserScan laser_scan
-bool[] reflektor_status
-bool[] reflektor_median
+bool[] reflector_status
+bool[] reflector_median
 bool[] intrusion
 


### PR DESCRIPTION
As the reflector information from the extended scan (reflector_status, reflector_median) is more reliable for for reflector marker detection, I've add an option to fill the intensity from the default scan message with the info provided in either the reflector_status or reflector_median. This is then kind of a similar behavior as the old sick s300 scan driver had and enables backwards compatibility.
As default the drivers behavior is unchanged.