### PR TITLE
Add missing map include.

### DIFF
--- a/include/sick_safetyscanners/data_processing/UDPPacketMerger.h
+++ b/include/sick_safetyscanners/data_processing/UDPPacketMerger.h
@@ -41,6 +41,7 @@
 #include <sick_safetyscanners/data_processing/ParseDatagramHeader.h>
 
 #include <algorithm>
+#include <map>
 #include <mutex>
 
 namespace sick {


### PR DESCRIPTION
Current code fails with `gcc (GCC) 11.3.0`

Error:
```
In file included from /home/iwanders/Documents/workspace/NIX/ws/src/sick_safetyscanners/src/data_processing/UDPPacketMerger.cpp:35:
/home/iwanders/Documents/workspace/NIX/ws/src/sick_safetyscanners/include/sick_safetyscanners/data_processing/UDPPacketMerger.h:87:8: error: ‘map’ in namespace ‘std’ does not name a template type
   87 |   std::map<uint32_t, sick::datastructure::ParsedPacketBuffer::ParsedPacketBufferVector>
      |        ^~~
/home/iwanders/Documents/workspace/NIX/ws/src/sick_safetyscanners/include/sick_safetyscanners/data_processing/UDPPacketMerger.h:42:1: note: ‘std::map’ is defined in header ‘<map>’; did you forget to ‘#include <map>’?
   41 | #include <sick_safetyscanners/data_processing/ParseDatagramHeader.h>
  +++ |+#include <map>
   42 | 
```

fyi @mikepurvis 