### PR TITLE
Add pending command mutex

### DIFF
--- a/include/sick_safetyscanners/cola2/Cola2Session.h
+++ b/include/sick_safetyscanners/cola2/Cola2Session.h
@@ -50,123 +50,119 @@
 #include <limits>
 #include <map>
 
-namespace sick {
-namespace cola2 {
-
-/*!
- * \brief Forward declaration of command class.
- */
-class Command;
-
-
-/*!
- * \brief Forward declaration of create session class.
- */
-class CreateSession;
-
-
-/*!
- * \brief Establishes a cola2 session with a sensor and enables execution of commands in this
- * session.
- */
-class Cola2Session
+namespace sick
 {
-public:
-  /*!
-   * \brief Typedef for a pointer containing a command to be executed.
-   */
-  typedef std::shared_ptr<sick::cola2::Command> CommandPtr;
+  namespace cola2
+  {
 
-  /*!
-   * \brief Constructor of the cola2 session.
-   *
-   * \param async_tcp_client Pointer to an instance of a TCP-client. Will be used to establish a
-   * connection to the sensor.
-   */
-  explicit Cola2Session(const std::shared_ptr<communication::AsyncTCPClient>& async_tcp_client);
+    /*!
+     * \brief Forward declaration of command class.
+     */
+    class Command;
 
+    /*!
+     * \brief Forward declaration of create session class.
+     */
+    class CreateSession;
 
-  /*!
-   * \brief Triggers the disconnection of the tcp socket.
-   */
-  void doDisconnect();
+    /*!
+     * \brief Establishes a cola2 session with a sensor and enables execution of commands in this
+     * session.
+     */
+    class Cola2Session
+    {
+    public:
+      /*!
+       * \brief Typedef for a pointer containing a command to be executed.
+       */
+      typedef std::shared_ptr<sick::cola2::Command> CommandPtr;
 
-  /*!
-   * \brief Executes the command passed to the function.
-   *
-   * \param command The command to be executed.
-   *
-   * \returns If the execution was successful.
-   */
-  bool executeCommand(const CommandPtr& command);
+      /*!
+       * \brief Constructor of the cola2 session.
+       *
+       * \param async_tcp_client Pointer to an instance of a TCP-client. Will be used to establish a
+       * connection to the sensor.
+       */
+      explicit Cola2Session(const std::shared_ptr<communication::AsyncTCPClient> &async_tcp_client);
 
-  /*!
-   * \brief Returns the current session ID.
-   *
-   * \returns The current session ID.
-   */
-  uint32_t getSessionID() const;
+      /*!
+       * \brief Triggers the disconnection of the tcp socket.
+       */
+      void doDisconnect();
 
-  /*!
-   * \brief Sets the current session ID.
-   *
-   * \param session_id The new session ID.
-   */
-  void setSessionID(const uint32_t& session_id);
+      /*!
+       * \brief Executes the command passed to the function.
+       *
+       * \param command The command to be executed.
+       *
+       * \returns If the execution was successful.
+       */
+      bool executeCommand(const CommandPtr &command);
 
-  /*!
-   * \brief Returns the next request ID. The request ID is used to match the return packages of the
-   * sensor to the right command.
-   *
-   * \returns A new request ID.
-   */
-  uint16_t getNextRequestID();
+      /*!
+       * \brief Returns the current session ID.
+       *
+       * \returns The current session ID.
+       */
+      uint32_t getSessionID() const;
 
+      /*!
+       * \brief Sets the current session ID.
+       *
+       * \param session_id The new session ID.
+       */
+      void setSessionID(const uint32_t &session_id);
 
-  /*!
-   * \brief Closes a session with the sensor. Executes the close session command.
-   *
-   * \returns If closing the session was successful.
-   */
-  bool close();
+      /*!
+       * \brief Returns the next request ID. The request ID is used to match the return packages of the
+       * sensor to the right command.
+       *
+       * \returns A new request ID.
+       */
+      uint16_t getNextRequestID();
 
+      /*!
+       * \brief Closes a session with the sensor. Executes the close session command.
+       *
+       * \returns If closing the session was successful.
+       */
+      bool close();
 
-  /*!
-   * \brief Opens a session with the sensor. Executes the create session command.
-   *
-   * \returns If opening a session was successful.
-   */
-  bool open();
+      /*!
+       * \brief Opens a session with the sensor. Executes the create session command.
+       *
+       * \returns If opening a session was successful.
+       */
+      bool open();
 
+    private:
+      std::shared_ptr<sick::communication::AsyncTCPClient> m_async_tcp_client_ptr;
+      std::shared_ptr<sick::data_processing::ParseTCPPacket> m_parser_ptr;
+      std::shared_ptr<sick::data_processing::TCPPacketMerger> m_packet_merger_ptr;
+      std::shared_ptr<sick::data_processing::ParseTCPPacket> m_tcp_parser_ptr;
 
-private:
-  std::shared_ptr<sick::communication::AsyncTCPClient> m_async_tcp_client_ptr;
-  std::shared_ptr<sick::data_processing::ParseTCPPacket> m_parser_ptr;
-  std::shared_ptr<sick::data_processing::TCPPacketMerger> m_packet_merger_ptr;
-  std::shared_ptr<sick::data_processing::ParseTCPPacket> m_tcp_parser_ptr;
+      std::map<uint16_t, CommandPtr> m_pending_commands_map;
 
-  std::map<uint16_t, CommandPtr> m_pending_commands_map;
+      boost::mutex m_command_map_mutex;
+      boost::mutex m_execution_mutex;
 
-  boost::mutex m_execution_mutex;
+      uint32_t m_session_id;
+      uint16_t m_last_request_id;
 
-  uint32_t m_session_id;
-  uint16_t m_last_request_id;
+      void processPacket(const sick::datastructure::PacketBuffer &packet);
 
-  void processPacket(const sick::datastructure::PacketBuffer& packet);
+      bool addCommand(const uint16_t &request_id, const CommandPtr &command);
+      bool findCommand(const uint16_t &request_id, CommandPtr &command);
+      bool removeCommand(const uint16_t &request_id);
 
-  bool addCommand(const uint16_t& request_id, const CommandPtr& command);
-  bool findCommand(const uint16_t& request_id, CommandPtr& command);
-  bool removeCommand(const uint16_t& request_id);
+      bool
+      startProcessingAndRemovePendingCommandAfterwards(const sick::datastructure::PacketBuffer &packet);
+      bool addPacketToMerger(const sick::datastructure::PacketBuffer &packet);
+      bool checkIfPacketIsCompleteAndOtherwiseListenForMorePackets();
+      bool sendTelegramAndListenForAnswer(const CommandPtr &command);
+    };
 
-  bool
-  startProcessingAndRemovePendingCommandAfterwards(const sick::datastructure::PacketBuffer& packet);
-  bool addPacketToMerger(const sick::datastructure::PacketBuffer& packet);
-  bool checkIfPacketIsCompleteAndOtherwiseListenForMorePackets();
-  bool sendTelegramAndListenForAnswer(const CommandPtr& command);
-};
-
-
-} // namespace cola2
+  } // namespace cola2
 } // namespace sick
 
 #endif // SICK_SAFETYSCANNERS_COLA2_COLA2SESSION_H

--- a/src/cola2/Cola2Session.cpp
+++ b/src/cola2/Cola2Session.cpp
@@ -34,149 +34,153 @@
 
 #include <sick_safetyscanners/cola2/Cola2Session.h>
 
-namespace sick {
-namespace cola2 {
-
-Cola2Session::Cola2Session(const std::shared_ptr<communication::AsyncTCPClient>& async_tcp_client)
-  : m_async_tcp_client_ptr(async_tcp_client)
-  , m_session_id(0)
-  , m_last_request_id(0)
+namespace sick
 {
-  m_async_tcp_client_ptr->setPacketHandler(boost::bind(&Cola2Session::processPacket, this, _1));
-  m_packet_merger_ptr = std::make_shared<sick::data_processing::TCPPacketMerger>();
-  m_tcp_parser_ptr    = std::make_shared<sick::data_processing::ParseTCPPacket>();
-}
-
-bool Cola2Session::open()
-{
-  CommandPtr command_ptr = std::make_shared<CreateSession>(boost::ref(*this));
-  return executeCommand(command_ptr);
-}
-
-bool Cola2Session::close()
-{
-  CommandPtr command_ptr = std::make_shared<CloseSession>(boost::ref(*this));
-  return executeCommand(command_ptr);
-}
-
-void Cola2Session::doDisconnect()
-{
-  m_async_tcp_client_ptr->doDisconnect();
-}
-
-bool Cola2Session::executeCommand(const CommandPtr& command)
-{
-  addCommand(command->getRequestID(), command);
-  sendTelegramAndListenForAnswer(command);
-  return true;
-}
-
-bool Cola2Session::sendTelegramAndListenForAnswer(const CommandPtr& command)
-{
-  command->lockExecutionMutex(); // lock
-  std::vector<uint8_t> telegram;
-  telegram = command->constructTelegram(telegram);
-  m_async_tcp_client_ptr->doSendAndReceive(telegram);
-  command->waitForCompletion(); // scooped locked to wait, unlocked on data processing
-  return true;
-}
-
-
-uint32_t Cola2Session::getSessionID() const
-{
-  return m_session_id;
-}
-
-void Cola2Session::setSessionID(const uint32_t& session_id)
-{
-  m_session_id = session_id;
-}
-
-void Cola2Session::processPacket(const datastructure::PacketBuffer& packet)
-{
-  addPacketToMerger(packet);
-  if (!checkIfPacketIsCompleteAndOtherwiseListenForMorePackets())
+  namespace cola2
   {
-    return;
-  }
-  sick::datastructure::PacketBuffer deployed_packet =
-    m_packet_merger_ptr->getDeployedPacketBuffer();
-  startProcessingAndRemovePendingCommandAfterwards(deployed_packet);
-}
 
-bool Cola2Session::addPacketToMerger(const sick::datastructure::PacketBuffer& packet)
-{
-  if (m_packet_merger_ptr->isEmpty() || m_packet_merger_ptr->isComplete())
-  {
-    m_packet_merger_ptr->setTargetSize(m_tcp_parser_ptr->getExpectedPacketLength(packet));
-  }
-  m_packet_merger_ptr->addTCPPacket(packet);
-  return true;
-}
+    Cola2Session::Cola2Session(const std::shared_ptr<communication::AsyncTCPClient> &async_tcp_client)
+        : m_async_tcp_client_ptr(async_tcp_client), m_session_id(0), m_last_request_id(0)
+    {
+      m_async_tcp_client_ptr->setPacketHandler(boost::bind(&Cola2Session::processPacket, this, _1));
+      m_packet_merger_ptr = std::make_shared<sick::data_processing::TCPPacketMerger>();
+      m_tcp_parser_ptr = std::make_shared<sick::data_processing::ParseTCPPacket>();
+    }
 
-bool Cola2Session::checkIfPacketIsCompleteAndOtherwiseListenForMorePackets()
-{
-  if (!m_packet_merger_ptr->isComplete())
-  {
-    m_async_tcp_client_ptr->initiateReceive();
-    return false;
-  }
-  return true;
-}
+    bool Cola2Session::open()
+    {
+      CommandPtr command_ptr = std::make_shared<CreateSession>(boost::ref(*this));
+      return executeCommand(command_ptr);
+    }
 
+    bool Cola2Session::close()
+    {
+      CommandPtr command_ptr = std::make_shared<CloseSession>(boost::ref(*this));
+      return executeCommand(command_ptr);
+    }
 
-bool Cola2Session::startProcessingAndRemovePendingCommandAfterwards(
-  const sick::datastructure::PacketBuffer& packet)
-{
-  uint16_t request_id = m_tcp_parser_ptr->getRequestID(packet);
-  CommandPtr pending_command;
-  if (findCommand(request_id, pending_command))
-  {
-    pending_command->processReplyBase(*packet.getBuffer());
-    removeCommand(request_id);
-  }
-  return true;
-}
+    void Cola2Session::doDisconnect()
+    {
+      m_async_tcp_client_ptr->doDisconnect();
+    }
 
-bool Cola2Session::addCommand(const uint16_t& request_id, const CommandPtr& command)
-{
-  if (m_pending_commands_map.find(request_id) != m_pending_commands_map.end())
-  {
-    return false;
-  }
-  m_pending_commands_map[request_id] = command;
-  return true;
-}
+    bool Cola2Session::executeCommand(const CommandPtr &command)
+    {
+      addCommand(command->getRequestID(), command);
+      sendTelegramAndListenForAnswer(command);
+      return true;
+    }
 
-bool Cola2Session::findCommand(const uint16_t& request_id, CommandPtr& command)
-{
-  if (m_pending_commands_map.find(request_id) == m_pending_commands_map.end())
-  {
-    return false;
-  }
-  command = m_pending_commands_map[request_id];
-  return true;
-}
+    bool Cola2Session::sendTelegramAndListenForAnswer(const CommandPtr &command)
+    {
+      command->lockExecutionMutex(); // lock
+      std::vector<uint8_t> telegram;
+      telegram = command->constructTelegram(telegram);
+      m_async_tcp_client_ptr->doSendAndReceive(telegram);
+      command->waitForCompletion(); // scooped locked to wait, unlocked on data processing
+      return true;
+    }
 
-bool Cola2Session::removeCommand(const uint16_t& request_id)
-{
-  auto it = m_pending_commands_map.find(request_id);
-  if (it == m_pending_commands_map.end())
-  {
-    return false;
-  }
-  m_pending_commands_map.erase(it);
-  return true;
-}
+    uint32_t Cola2Session::getSessionID() const
+    {
+      return m_session_id;
+    }
 
-uint16_t Cola2Session::getNextRequestID()
-{
-  if (m_last_request_id == std::numeric_limits<uint16_t>::max())
-  {
-    m_last_request_id = 0;
-  }
-  return ++m_last_request_id;
-}
+    void Cola2Session::setSessionID(const uint32_t &session_id)
+    {
+      m_session_id = session_id;
+    }
 
-} // namespace cola2
+    void Cola2Session::processPacket(const datastructure::PacketBuffer &packet)
+    {
+      addPacketToMerger(packet);
+      if (!checkIfPacketIsCompleteAndOtherwiseListenForMorePackets())
+      {
+        return;
+      }
+      sick::datastructure::PacketBuffer deployed_packet =
+          m_packet_merger_ptr->getDeployedPacketBuffer();
+      startProcessingAndRemovePendingCommandAfterwards(deployed_packet);
+    }
+
+    bool Cola2Session::addPacketToMerger(const sick::datastructure::PacketBuffer &packet)
+    {
+      if (m_packet_merger_ptr->isEmpty() || m_packet_merger_ptr->isComplete())
+      {
+        m_packet_merger_ptr->setTargetSize(m_tcp_parser_ptr->getExpectedPacketLength(packet));
+      }
+      m_packet_merger_ptr->addTCPPacket(packet);
+      return true;
+    }
+
+    bool Cola2Session::checkIfPacketIsCompleteAndOtherwiseListenForMorePackets()
+    {
+      if (!m_packet_merger_ptr->isComplete())
+      {
+        m_async_tcp_client_ptr->initiateReceive();
+        return false;
+      }
+      return true;
+    }
+
+    bool Cola2Session::startProcessingAndRemovePendingCommandAfterwards(
+        const sick::datastructure::PacketBuffer &packet)
+    {
+      uint16_t request_id = m_tcp_parser_ptr->getRequestID(packet);
+      CommandPtr pending_command;
+      if (findCommand(request_id, pending_command))
+      {
+        pending_command->processReplyBase(*packet.getBuffer());
+        removeCommand(request_id);
+      }
+      return true;
+    }
+
+    bool Cola2Session::addCommand(const uint16_t &request_id, const CommandPtr &command)
+    {
+      boost::mutex::scoped_lock lock(m_command_map_mutex);
+
+      if (m_pending_commands_map.find(request_id) != m_pending_commands_map.end())
+      {
+        return false;
+      }
+      m_pending_commands_map[request_id] = command;
+      return true;
+    }
+
+    bool Cola2Session::findCommand(const uint16_t &request_id, CommandPtr &command)
+    {
+      boost::mutex::scoped_lock lock(m_command_map_mutex);
+
+      if (m_pending_commands_map.find(request_id) == m_pending_commands_map.end())
+      {
+        return false;
+      }
+      command = m_pending_commands_map[request_id];
+      return true;
+    }
+
+    bool Cola2Session::removeCommand(const uint16_t &request_id)
+    {
+      boost::mutex::scoped_lock lock(m_command_map_mutex);
+
+      auto it = m_pending_commands_map.find(request_id);
+      if (it == m_pending_commands_map.end())
+      {
+        return false;
+      }
+      m_pending_commands_map.erase(it);
+      return true;
+    }
+
+    uint16_t Cola2Session::getNextRequestID()
+    {
+      if (m_last_request_id == std::numeric_limits<uint16_t>::max())
+      {
+        m_last_request_id = 0;
+      }
+      return ++m_last_request_id;
+    }
+
+  } // namespace cola2
 } // namespace sick


### PR DESCRIPTION
### Info
Similar to [this](https://github.com/SICKAG/sick_safetyscanners/issues/114) issue, a segmentation fault in cola2session crashed multiple scan ROS nodes several times.  Although the actual triggering event of the problem could not really be identified, this fix should limit the concurrent access to the pending commands and thus avoid the error.

Fixes #114 

### Changes
- Added a mutex to restrict simultaneous access to pending commands