### PR TITLE
application data offset correction

### DIFF
--- a/src/data_processing/ParseApplicationData.cpp
+++ b/src/data_processing/ParseApplicationData.cpp
@@ -319,13 +319,13 @@ void ParseApplicationData::setMonitoringCaseFlagsInApplicationOutputs(
 void ParseApplicationData::setSleepModeOutputInApplicationOutputs(
   std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
 {
-  outputs.setSleepModeOutput(read_write_helper::readUint8LittleEndian(data_ptr + 193));
+  outputs.setSleepModeOutput(read_write_helper::readUint8LittleEndian(data_ptr + 196));
 }
 
 void ParseApplicationData::setErrorFlagsInApplicationOutputs(
   std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
 {
-  uint8_t word8 = read_write_helper::readUint8LittleEndian(data_ptr + 194);
+  uint8_t word8 = read_write_helper::readUint8LittleEndian(data_ptr + 197);
 
   outputs.setHostErrorFlagContaminationWarning(static_cast<bool>(word8 & (0x01 << 0)));
   outputs.setHostErrorFlagContaminationError(static_cast<bool>(word8 & (0x01 << 1)));
@@ -404,7 +404,7 @@ void ParseApplicationData::setResultingVelocityFlagsInApplicationOutputs(
 void ParseApplicationData::setOutputFlagsinApplicationOutput(
   std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
 {
-  uint8_t word8 = read_write_helper::readUint8LittleEndian(data_ptr + 259);
+  uint8_t word8 = read_write_helper::readUint8LittleEndian(data_ptr + 263);
 
   outputs.setFlagsSleepModeOutputIsValid(static_cast<bool>(word8 & (0x01 << 0)));
   outputs.setFlagsHostErrorFlagsAreValid(static_cast<bool>(word8 & (0x01 << 1)));


### PR DESCRIPTION
Hello, this PR corrects the offsets for the application data (outputs) block.

**Observed Problem:**
The following parameters don't update from the values they are initialized to in the [raw_data topic](https://github.com/SICKAG/sick_safetyscanners/blob/2db7ecb00ba0c0685359e048f17856837855f1e1/src/SickSafetyscannersRos.cpp#L64) (seen on a nanoScan3):
- sleep_mode_output
- sleep_mode_output_valid
- error_flag_contamination_warning
- error_flag_contamination_error
- error_flag_manipulation_error
- error_flag_glare
- error_flag_reference_contour_intruded
- error_flag_critical_error
- error_flags_are_valid

**Solution:**
Found a mismatch between the correct offsets in the application data (outputs) block as specified by [the technical documentation](https://cdn.sick.com/media/docs/1/01/701/technical_information_microscan3_outdoorscan3_nanoscan3_data_output_via_udp_and_tcp_ip_en_im0083701.pdf) and what is implemented in this driver.

**Testing:**
I implemented the updated offsets on a nanoScan3, triggered the warning/error flags (contamination, etc.) and saw that the flags in the raw_data topic updated as expected.